### PR TITLE
Strip CHEBI prefix out of CHEBI ids

### DIFF
--- a/indra_db/util.py
+++ b/indra_db/util.py
@@ -8,7 +8,7 @@ Some key functions' capabilities include:
 
 __all__ = ['get_defaults', 'get_primary_db', 'get_db', 'insert_agents',
            'insert_pa_stmts', 'insert_db_stmts', 'get_raw_stmts_frm_db_list',
-           'distill_stmts']
+           'distill_stmts', 'regularize_agent_id']
 
 import re
 import json
@@ -289,6 +289,14 @@ def insert_pa_agents_directly(db, stmts, verbose=False):
     return
 
 
+def regularize_agent_id(id_val, id_ns):
+    """Change agent ids for better search-ability and index-ability."""
+    if id_ns.upper() == 'CHEBI':
+        if id_val.startswith('CHEBI'):
+            id_val = id_val[6:]
+    return id_val
+
+
 def _get_agent_tuples(stmt, stmt_id):
     """Create the tuples for copying agents into the database."""
     # Figure out how the agents are structured and assign roles.
@@ -303,13 +311,6 @@ def _get_agent_tuples(stmt, stmt_id):
         raise IndraDatabaseError("Unhandled agent structure for stmt %s "
                                  "with agents: %s."
                                  % (str(stmt), str(stmt.agent_list())))
-
-    def opt_ag_id(id_val, id_ns):
-        """Change agent ids for better search-ability and index-ability."""
-        if id_ns.upper() == 'CHEBI':
-            if id_val.startswith('CHEBI'):
-                id_val = id_val[6:]
-        return id_val
 
     def all_agent_refs(agents):
         """Smooth out the iteration over agents and their refs."""
@@ -328,7 +329,7 @@ def _get_agent_tuples(stmt, stmt_id):
     # Prep the agents for copy into the database.
     agent_data = []
     for ns, ag_id, role in all_agent_refs(agents):
-        agent_data.append((stmt_id, ns, opt_ag_id(ag_id, ns), role))
+        agent_data.append((stmt_id, ns, regularize_agent_id(ag_id, ns), role))
     return agent_data
 
 

--- a/indra_db/util.py
+++ b/indra_db/util.py
@@ -291,10 +291,12 @@ def insert_pa_agents_directly(db, stmts, verbose=False):
 
 def regularize_agent_id(id_val, id_ns):
     """Change agent ids for better search-ability and index-ability."""
+    new_id_val = id_val
     if id_ns.upper() == 'CHEBI':
         if id_val.startswith('CHEBI'):
-            id_val = id_val[6:]
-    return id_val
+            new_id_val = id_val[6:]
+            logger.info("Fixed agent id: %s -> %s" % (id_val, new_id_val))
+    return new_id_val
 
 
 def _get_agent_tuples(stmt, stmt_id):

--- a/indra_db/util.py
+++ b/indra_db/util.py
@@ -398,6 +398,8 @@ def insert_pa_stmts(db, stmts, verbose=False, do_copy=True,
     verbose : bool
         If True, print extra information and a status bar while compiling
         statements for insert. Default False.
+    do_copy : bool
+        If True (default), use pgcopy to quickly insert the agents.
     direct_agent_load : bool
         If True (default), use the Statement get_hash method to get the id's of
         the Statements for insert, instead of looking up the ids of Statements
@@ -427,7 +429,7 @@ def insert_pa_stmts(db, stmts, verbose=False, do_copy=True,
         db.copy('pa_statements', stmt_data, cols)
     else:
         db.insert_many('pa_statements', stmt_data, cols=cols)
-    if insert_pa_agents_directly:
+    if direct_agent_load:
         insert_pa_agents_directly(db, stmts, verbose=verbose)
     else:
         insert_agents(db, 'pa', verbose=verbose)


### PR DESCRIPTION
When sorting and searching for values in the database, the identical for all CHEBI ids slows look-ups significantly. This PR removes them for entry into the database.