### PR TITLE
Update the REST API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ processing systems at scale:
 with content drawn from:
 - [PubMed](https://www.ncbi.nlm.nih.gov/pubmed/) - ~28 million abstracts
 - [PubMed Central](/www.ncbi.nlm.nih.gov/pmc/) - ~5 million fulltext
-- [Elsevier](https://www.elsevier.com/) - fulltext (requires special access)
+- [Elsevier](https://www.elsevier.com/) - ~0.7 million fulltext 
+(requires special access)
 
 We also collect information from these databases:
 - [Pathway Commons database](http://pathwaycommons.org/)

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -181,11 +181,30 @@ a list of dicts, each containing id type and and id value.
 <a name="curation"></a>
 ## Curation
 
-A recent feature of the INDRA Database allows the collection of curation 
-information pertaining to both pre-assembled and raw Statments. The REST API
-provide an endpoint to submit these curations.
+Because the mechanisms represented by our Statements come in large part from
+automatic extractions, there can often be errors. For this reason, we always
+provide the sentences from which a Statement was extracted (if we extracted
+it, some of our content comes from other curated databases), as well as
+provenance to lead back to the content (abstract, full text, etc.) that was
+read, all so that you can use your own judgement regarding the validity and
+relevance of a Statement.
+
+If you find something wrong with a Statement, you can use this curation
+endpoint to record your observation. This will not necessarily have any 
+immediate effect on the output, however, over time it will help us improve the
+readers we use, our methods for extracting Statements from those reader
+outputs, and could help us filter erroneous content.
 
 ### Curate statements: `POST api.host/curation/submit/<level>/<hash>`
+
+If you wish to curate a Statement, you must first decide whether you are
+curating the piece of knowledge, for example "differentiation binds apoptosis",
+which would be at the "pa" level (short for pre-assembled), or if you are
+curating a particular extraction, for example the sentence "IR causes cell 
+death", where IR is Ionizing Radiation, is instead extracted as "'Insulin 
+Receptor' causes cell death". This would be an example of a grounding error,
+and although it may happen often, it is at the extraction, "raw", level.
+
 
 ## Usage examples
 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -355,7 +355,8 @@ For those familiar with pre-assembled INDRA Statements, note that the
 populated.
 
 INDRA also supports a client to this API, which is documented in detail
-elsewhere, however using that client, the above query is simply:
+[elsewhere](https://indra.readthedocs.io/en/latest/modules/sources/indra_db_rest/index.html),
+however using that client, the above query is simply:
 ```python
 from indra.sources import indra_db_rest as idbr
 stmts = idbr.get_statements(subject='MAP2K1', object='MAPK1', stmt_type='phosphorylation')

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -17,10 +17,10 @@ of this writing, the API supports:
 - [`statements/from_hash`](#from-hash) and
  [`statements/from_hashes`](#from-hashes), getting Statements by Statement 
  hash, either singly or in batches, and
-- `statements/from_papers`, getting Statements using the paper ids from
- which they were extracted, and
-- `curation/submit/<level>/<hash>` you can also curate Statements, helping us
- improve the quality and accuracy of our content.
+- [`statements/from_papers`](#from-papers), getting Statements using the paper 
+ ids from which they were extracted, and
+- [`curation/submit/<level>/<hash>`](#curation) you can also curate Statements, 
+ helping us improve the quality and accuracy of our content.
 
 As mentioned, the service is changing rapidly, and this documentation may at
 times be out of date. For the latest, check github or contact us.
@@ -131,7 +131,7 @@ the type of Statement. The query parameters are as follows:
    give the same result.
 
 <a name="from-hash"></a> 
-### Get a Statement by hash: `GET api.host/statements/from_hash`
+### Get a Statement by hash: `GET api.host/statements/from_hash/<hash>`
 
 INDRA Statement objects have a method, `get_hash`, which produces hash from 
 the content of the Statement. A shallow hash only considers the meaning of 
@@ -177,6 +177,15 @@ this to be a POST request. The papers ids should be formatted as:
 ```
 a list of dicts, each containing id type and and id value.
 
+
+<a name="curation"></a>
+## Curation
+
+A recent feature of the INDRA Database allows the collection of curation 
+information pertaining to both pre-assembled and raw Statments. The REST API
+provide an endpoint to submit these curations.
+
+### Curate statements: `POST api.host/curation/submit/<level>/<hash>`
 
 ## Usage examples
 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -42,7 +42,7 @@ up and running.
 ## The Statement Endpoints
 
 For all queries, an API key is required, which is passed as a parameter
-`api-key` to any/all queries. Below is detailed documentation for the
+`api_key` to any/all queries. Below is detailed documentation for the
 different endpoints of the API that return statements (i.e. those with the root
 `/statements`). All endpoints that return statements have the following
 options to control the size and order of the response:
@@ -247,41 +247,112 @@ correct Statements can be just as valuable as flagging incorrect Statements.
 
 ## Usage examples
 
-The web service accepts standard GET requests, and any client that can
-send such requests can be used to interact with the service. Note, however,
-that access directly via a browser can be complicated by the
-use of API keys which have to be included in the request header. Here we
-provide usage examples with the `curl` command line tool and `python`.
+The web service accepts standard HTTP requests, and any client that can
+send such requests can be used to interact with the service. Here we
+provide usage examples with the `curl` command line tool and `python` of 
+some of the endpoints. This is by no means a comprehensive list, but rather 
+demonstrates some of the crucial features discussed above.
 
-In the examples, let's assume the path to the web API is
-`https://api.host/`, and that the API key is `12345`.
+In the examples, we assume the path to the web API is `https://api.host/`, and
+that the API key is `12345`.
 
 ### Curl
 `curl` is a command line tool on Linux and Mac, making it a convenient tool
 for making calls to this web API.
 
-Example 1: Using `curl`, a query for "MAP2K1 phophorylates MAPK1" can be sent
-as:
+*Example 1*: Query Statements about "MAP2K1 phosphorylates MAPK1"
 ```bash
-curl -i -H "x-api-key:12345" -X GET "https://api.host/statements/?subject=MAP2K1&object=MAPK1&type=phosphorylation"
+curl -X GET "http://api.host/statements/from_agents?subject=MAP2K1&object=MAPK1&type=phosphorylation&api_key=12345"
 ```
-which will return a JSON list of Statements. Note that if there is no API key,
-you can simply remove `-H "x-api-key:12345"` from the command.
+<details><summary>This will return the following JSON (pretty printed here for 
+readability):<summary><p>
+```json
+{
+  "statements": {
+    "-1072112758478440": {
+      "id": "5c3dff5f-6660-4494-96d2-0142076e9b2f",
+      "enz": {
+        "name": "MAP2K1",
+        "db_refs": {
+          "UP": "Q02750",
+          "HGNC": "6840"
+        },
+        "sbo": "http://identifiers.org/sbo/SBO:0000460"
+      },
+      "sbo": "http://identifiers.org/sbo/SBO:0000216",
+      "evidence": [
+        {
+          "source_api": "reach",
+          "epistemics": {
+            "section_type": null,
+            "direct": true
+          },
+          "text": "Thus, free non visual arrestins moderately facilitate the phosphorylation of ERK2 by MEK1.",
+          "pmid": "22174878",
+          "annotations": {
+            "agents": {
+              "raw_text": [
+                "MEK1",
+                "ERK2"
+              ]
+            },
+            "content_source": "pmc_oa",
+            "prior_uuids": [
+              "55afb6fc-5649-4315-94bc-3ce0651fc1d3"
+            ],
+            "found_by": "Phosphorylation_syntax_1a_noun"
+          }
+        }
+      ],
+      "type": "Phosphorylation",
+      "sub": {
+        "name": "MAPK1",
+        "db_refs": {
+          "UP": "P28482",
+          "HGNC": "6871"
+        },
+        "sbo": "http://identifiers.org/sbo/SBO:0000015"
+      }
+    }
+  },
+  "offset": null,
+  "total_evidence": 106,
+  "evidence_totals": {
+    "-1072112758478440": 106
+  },
+  "evidence_returned": 1,
+  "evidence_limit": "1",
+  "statement_limit": 1000
+}
+```
+</p></details>
 
-Example 2: If we instead want to know if there is any support for the
-proposition there is some kind of interaction between SMURF2 and SMAD2,
-your `curl` query would be:
+*Example 2*: Query for any kind of interaction between SMURF2 and SMAD2:
 ```bash
-curl -i -H "x-api-key:12345" -X GET "https://api.host/statements/?
-agent=SMURF2&agent=SMAD2"
-```
-Or, if you are using our implementation of the REST service, you would
-need to use
-```bash
-curl -i -H "x-api-key:12345" -X GET "https://api.host/statements/?
-agent0=SMURF2&agentbondjamesbond=SMAD2"
+curl -X GET "http://api.host/statements/from_agents?agent0=SMURF2&agent1=SMAD2&api_key=12345"
 ```
 
+*Example 3*: Query for a statement with the hash -1072112758478440, retrieving
+at most 1000 evidence.:
+```bash
+curl -X GET "http://api.host/statements/from_hash/-1072112758478440?api_key=12345&ev_limit=1000"
+```
+
+*Example 4*: Get the statements from a paper with the pmid 22174878, and
+another paper with the doi 10.1259/0007-1285-34-407-693, first create the json
+file, call it `papers.json` with the following:
+```json
+{
+  "ids": [
+    {"id": "22174878", "type": "pmid"},
+    {"id": "10.1259/0007-1285-34-407-693", "type": "doi"}
+  ]
+}
+```
+and post it to the REST API with curl:
+```bash
+curl -X POST "http://api.host/statements/from_papers" -H "Content-Type: application/json" -d @papers.json
+```
 
 ### Python
 Python is a convenient way to use this web API and has the important

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -38,13 +38,13 @@ the user. We have had success using [Zappa](https://github.com/Miserlou/Zappa)
 and AWS Lambda, and recommend it for a quick and efficient way to get the API
 up and running.
 
-## The Endpoints
+## The Statement Endpoints
 
 For all queries, an API key is required, which is passed as a parameter
 `api-key` to any/all queries. Below is detailed documentation for the
-different endpoints of the API. In addition, all endpoints that return
-statements (i.e. those with the root `/statements`), have the following
-options to control the size of the response:
+different endpoints of the API that return statements (i.e. those with the root
+`/statements`). All endpoints that return statements have the following
+options to control the size and order of the response:
 - **`max_stmts`**: Set the maximum number of statements you wish to receive.
  The REST API maximum is 1000, which cannot be overridden by this argument
  (to prevent request timeouts).
@@ -58,6 +58,26 @@ options to control the size of the response:
  however they are also generally the most canonical. Set this parameter to 
  "false" to get statements in an arbitrary order. This can also speed up a 
  query. You may however find you get a lot of low-quality content.
+
+The output of the statement endpoint is JSON. Specifically, the endpoints 
+all return a json dict of the following form:
+```json
+{
+  "statements": {
+    "12345234234": <Statement JSON 1>,
+    "-246809323482": <Statement JSON 2>,
+    ...},
+  "offset": <offset of SQL query>,
+  "evidence_limit": <evidence limit used>,
+  "statement_limit": <REST API Limit>,
+  "evidence_totals": <evidence avilable for each statement>,
+  "total_evidence": <total evidence available for all returned statements>,
+  "evidence_returned": <total evidence returned>
+}
+```
+where the `"statements"` element contains a dictionary of INDRA Statement
+JSONs keyed by a shallow statement hash (see [here](#from-hash) for more
+details on these hashes).
 
 <a name="from-agents"></a>
 ### Get Statements by Agents (and Type): `api.host/statements/from_agents`
@@ -107,6 +127,13 @@ the type of Statement. The query parameters are as follows:
 
 <a name="from-hash"></a> 
 ### Get a Statement and it's Evidence by Hash: `api.host/statements/from_hash`
+
+INDRA Statement objects have a method, `get_hash`, which produces hash from 
+the content of the Statement. A shallow hash only considers the meaning of 
+the statement (agents, type, modifications, etc.), whereas a deeper hash also
+considers the list of evidence available for that Statement. The shallow hash
+is what is used in this application, as it has the same uniqueness 
+properties used in deduplication.
 
 ## Usage examples
 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -61,18 +61,18 @@ options to control the size and order of the response:
 
 The output of the statement endpoint is JSON. Specifically, the endpoints 
 all return a json dict of the following form:
-```json
+```python
 {
   "statements": {
-    "12345234234": <Statement JSON 1>,
-    "-246809323482": <Statement JSON 2>,
+    "12345234234": {...},  # Statement JSON 1
+    "-246809323482": {...},  # Statement JSON 2
     ...},
-  "offset": <offset of SQL query>,
-  "evidence_limit": <evidence limit used>,
-  "statement_limit": <REST API Limit>,
-  "evidence_totals": <evidence avilable for each statement>,
-  "total_evidence": <total evidence available for all returned statements>,
-  "evidence_returned": <total evidence returned>
+  "offset": 2000,  # offset of SQL query
+  "evidence_limit": 10,  # evidence limit used
+  "statement_limit": 1000,  # REST API Limit
+  "evidence_totals": {...}, # dict of available evidence for each statement keyed by hash
+  "total_evidence": 163708, # The total amount of evidence available
+  "evidence_returned": 10000  # The total amount of evidence returned
 }
 ```
 where the `"statements"` element contains a dictionary of INDRA Statement

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -329,6 +329,7 @@ Pretty printed for readability:
 ```
 </p>
 </details>
+<br>  
 
 *Example 2*: Query for any kind of interaction between SMURF2 and SMAD2:
 ```bash

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -264,8 +264,10 @@ for making calls to this web API.
 ```bash
 curl -X GET "http://api.host/statements/from_agents?subject=MAP2K1&object=MAPK1&type=phosphorylation&api_key=12345"
 ```
-<details><summary>This will return the following JSON (pretty printed here for 
-readability):<summary><p>
+<details><summary>This will return the following JSON:</summary>
+Pretty printed for readability:
+<p>
+
 ```json
 {
   "statements": {
@@ -325,7 +327,8 @@ readability):<summary><p>
   "statement_limit": 1000
 }
 ```
-</p></details>
+</p>
+</details>
 
 *Example 2*: Query for any kind of interaction between SMURF2 and SMAD2:
 ```bash

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -192,36 +192,40 @@ automatic extractions, there can often be errors. For this reason, we always
 provide the sentences from which a Statement was extracted (if we extracted
 it, some of our content comes from other curated databases), as well as
 provenance to lead back to the content (abstract, full text, etc.) that was
-read, all so that you can use your own judgement regarding the validity and
-relevance of a Statement.
+read, which allows you to use your own judgement regarding the validity of
+a Statement.
 
 If you find something wrong with a Statement, you can use this curation
 endpoint to record your observation. This will not necessarily have any
 immediate effect on the output, however, over time it will help us improve the
 readers we use, our methods for extracting Statements from those reader
-outputs, and could help us filter erroneous content.
+outputs, could help us filter erroneous content, and will help us improve our
+pre-assembly algorithms.
 
 ### Curate statements: `POST api.host/curation/submit/<level>/<hash>`
 
 If you wish to curate a Statement, you must first decide whether you are
-curating the piece of knowledge, or a particular extraction. This is the 
-"level" of your curation:
+curating the Statement as generally incorrect, or whether a particular
+sentence supports a given Statement. This is the "level" of your curation:
 - **pa**: At this level, you are curating the knowledge in a
  ***p**re-**a**ssembled* Statement. For example, if a Statement
  indicates that "differentiation binds apoptosis", regardless of whether the
  reader(s) made a valid extraction, it is clearly wrong.
 - **raw**: At this level, you are curating a particular *raw* extraction, in
- other words stating that an automatic reader made an error. For example the
- sentence "IR causes cell death", where IR is Ionizing Radiation, is instead
- extracted as "'Insulin Receptor' causes cell death". This would be an example
- of a grounding error, and although it may happen often enough to provide 
- large amounts of evidence, it is an extraction error.
+ other words stating that an automatic reader made an error. Even more
+ explicitly, you can judge whether the sentence supports the extracted
+ Statement. For example the (hypothetical) sentence "KRAS was found to actively
+ inhibit BRAF" does not support the Statement "KRAS activates BRAF". As another
+ example (here a grounding error), would be that the sentence "IR causes cell
+ death", where IR is Ionizing Radiation does not support the extraction "'Insulin
+ Receptor' causes cell death".
 
 The two different levels also have different hashes. At the *pa* level, the 
 hashes discussed [above](#from-hash) are used, as they are calculated from the 
-knowledge contained in the statement, independent of extraction. At the *raw*
-level, a different hash, the `source_hash` is used. Within a statement JSON,
-there is a key "evidence", with a list of Evidence JSON, which includes an 
+knowledge contained in the statement, independent of the evidence. At the *raw*
+level, a different hash, the `source_hash` is used, which identifies a specific
+piece of evidence, without considering the Statement extracted. Within a statement
+JSON, there is a key "evidence", with a list of Evidence JSON, which includes an 
 entry for "source_hash":
 ```python
 {"evidence": [{"source_hash": 98687578576598, ...}, ...], ...}

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -14,8 +14,9 @@ still under heavy development so capabilities are always expanding, but as
 of this writing, the API supports:
 - [`statements/from_agents`](#from-agents), getting Statements by agents, using
  various ids or names, by statement type (e.g. Phosphorylation), or
-- [`statements/from_hash`](#from-hash) and `statements/from_hashes`, getting
- Statements by Statement hash, either singly or in batches, and
+- [`statements/from_hash`](#from-hash) and
+ [`statements/from_hashes`](#from-hashes), getting Statements by Statement 
+ hash, either singly or in batches, and
 - `statements/from_papers`, getting Statements using the paper ids from
  which they were extracted, and
 - `curation/submit/<level>/<hash>` you can also curate Statements, helping us
@@ -60,17 +61,21 @@ options to control the size and order of the response:
  query. You may however find you get a lot of low-quality content.
 
 The output of the statement endpoint is JSON. Specifically, the endpoints 
-all return a json dict of the following form:
+all return a json dict of the following form (with many made-up but reasonable
+numbers):
 ```python
 {
-  "statements": {
+  "statements": {  # Dict of statement JSONs keyed by hash
     "12345234234": {...},  # Statement JSON 1
     "-246809323482": {...},  # Statement JSON 2
     ...},
   "offset": 2000,  # offset of SQL query
   "evidence_limit": 10,  # evidence limit used
   "statement_limit": 1000,  # REST API Limit
-  "evidence_totals": {...}, # dict of available evidence for each statement keyed by hash
+  "evidence_totals": {  # dict of available evidence for each statement keyed by hash
+    "12345234234": 7657,
+    "-246809323482": 870,
+    ...},
   "total_evidence": 163708, # The total amount of evidence available
   "evidence_returned": 10000  # The total amount of evidence returned
 }
@@ -80,7 +85,7 @@ JSONs keyed by a shallow statement hash (see [here](#from-hash) for more
 details on these hashes).
 
 <a name="from-agents"></a>
-### Get Statements by Agents (and Type): `api.host/statements/from_agents`
+### Get Statements by agents (and type): `GET api.host/statements/from_agents`
 
 This endpoint allows you to get statements filtering by their agents and 
 the type of Statement. The query parameters are as follows:
@@ -126,7 +131,7 @@ the type of Statement. The query parameters are as follows:
    give the same result.
 
 <a name="from-hash"></a> 
-### Get a Statement and it's Evidence by Hash: `api.host/statements/from_hash`
+### Get a Statement and it's Evidence by hash: `GET api.host/statements/from_hash`
 
 INDRA Statement objects have a method, `get_hash`, which produces hash from 
 the content of the Statement. A shallow hash only considers the meaning of 
@@ -134,6 +139,28 @@ the statement (agents, type, modifications, etc.), whereas a deeper hash also
 considers the list of evidence available for that Statement. The shallow hash
 is what is used in this application, as it has the same uniqueness 
 properties used in deduplication.
+
+This endpoint has no extra parameters, but rather takes an extention to the 
+path. So, to look up the hash 123456789, you would use 
+`statements/from_hash/123456789`.
+
+Because this only returns one statement, the default evidence limit is 
+extremely generous, set to 10,000. Thus you are most likely to get all the 
+evidence for a given statement this way. As described above, the evidence 
+limit can also be raised, at the risk of a timed out request.
+
+<a name="from-hashes"></a>
+### Get a Statement from many hashes: `POST api.host/statements/from_hashes`
+
+Like the previous endpoint, this endpoint uses hashes to retrieve Statements,
+however instead of only being allowed one at a time, a bach of 
+hashes may be sent as json data. Because data is sent, this is a POST request,
+even though you are in practice "getting" information. There are no special 
+parameters for this endpoint. The json data should be formatted as:
+```json
+{"hashes": [12345, 246810]}
+```
+with up to 1,000 hashes given in the list.
 
 ## Usage examples
 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -13,22 +13,21 @@ allows access to the pre-assembled Statements in a database. The system is
 still under heavy development so capabilities are always expanding, but as
 of this writing, the API supports:
 - [`statements/from_agents`](#from-agents), getting Statements by agents, using
-various ids or names, by statement type (e.g. Phosphorylation), or
- - `statements/from_hash` and `statements/from_hashes`, getting Statements by
-statement hash, either singly or in batches, and
+ various ids or names, by statement type (e.g. Phosphorylation), or
+- [`statements/from_hash`](#from-hash) and `statements/from_hashes`, getting
+ Statements by Statement hash, either singly or in batches, and
 - `statements/from_papers`, getting Statements using the paper ids from
-which they were extracted, and
+ which they were extracted, and
 - `curation/submit/<level>/<hash>` you can also curate Statements, helping us
-improve the quality and accuracy of our content.
+ improve the quality and accuracy of our content.
 
 As mentioned, the service is changing rapidly, and this documentation may at
 times be out of date. For the latest, check github or contact us.
 
 You need the following information to access a running web service:
-- The address of the web service (below shown with the placeholder
-`api.host`)
+- The address of the web service (below shown with the placeholder `api.host`)
 - An API key which needs to be sent in the header of each request to the
-service, or any other credentials that are implemented.
+ service, or any other credentials that are implemented.
 
 If you want to use our implementation of the web API, you can contact us for
 the path and an API key.
@@ -60,7 +59,8 @@ options to control the size of the response:
  "false" to get statements in an arbitrary order. This can also speed up a 
  query. You may however find you get a lot of low-quality content.
 
-###<a name="from-agents"></a> Get Statements by Agents (and Type): `api.host/statements/from_agents`
+<a name="from-agents"></a>
+### Get Statements by Agents (and Type): `api.host/statements/from_agents`
 
 This endpoint allows you to get statements filtering by their agents and 
 the type of Statement. The query parameters are as follows:
@@ -105,7 +105,8 @@ the type of Statement. The query parameters are as follows:
    Note that this field is not case sensitive, so `type=phosphorylation` would
    give the same result.
 
-###<a name="from-hash"></a> Get a Statement and it's Evidence by Hash: `api.host/statements/from_hash`
+<a name="from-hash"></a> 
+### Get a Statement and it's Evidence by Hash: `api.host/statements/from_hash`
 
 ## Usage examples
 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -137,10 +137,12 @@ INDRA Statement objects have a method, `get_hash`, which produces hash from
 the content of the Statement. A shallow hash only considers the meaning of 
 the statement (agents, type, modifications, etc.), whereas a deeper hash also
 considers the list of evidence available for that Statement. The shallow hash
-is what is used in this application, as it has the same uniqueness 
-properties used in deduplication.
+is what is used in this application, as it has the same uniqueness properties
+used in deduplication. As mentioned above, the Statements are returned keyed by
+their hash. In addition, if you construct a Statement in python, you may get
+its hash and quickly find any evidence for that Statement in the database.
 
-This endpoint has no extra parameters, but rather takes an extention to the 
+This endpoint has no extra parameters, but rather takes an extension to the 
 path. So, to look up the hash 123456789, you would use 
 `statements/from_hash/123456789`.
 
@@ -190,7 +192,7 @@ read, all so that you can use your own judgement regarding the validity and
 relevance of a Statement.
 
 If you find something wrong with a Statement, you can use this curation
-endpoint to record your observation. This will not necessarily have any 
+endpoint to record your observation. This will not necessarily have any
 immediate effect on the output, however, over time it will help us improve the
 readers we use, our methods for extracting Statements from those reader
 outputs, and could help us filter erroneous content.
@@ -198,12 +200,31 @@ outputs, and could help us filter erroneous content.
 ### Curate statements: `POST api.host/curation/submit/<level>/<hash>`
 
 If you wish to curate a Statement, you must first decide whether you are
-curating the piece of knowledge, for example "differentiation binds apoptosis",
-which would be at the "pa" level (short for pre-assembled), or if you are
-curating a particular extraction, for example the sentence "IR causes cell 
-death", where IR is Ionizing Radiation, is instead extracted as "'Insulin 
-Receptor' causes cell death". This would be an example of a grounding error,
-and although it may happen often, it is at the extraction, "raw", level.
+curating the piece of knowledge, or a particular extraction. This is the 
+"level" of your curation:
+- **pa**: At this level, you are curating the knowledge in a
+ ***p**re-**a**ssembled* Statement. For example, if a Statement
+ indicates that "differentiation binds apoptosis", regardless of whether the
+ reader(s) made a valid extraction, it is clearly wrong.
+- **raw**: At this level, you are curating a particular *raw* extraction, in
+ other words stating that an automatic reader made an error. For example the
+ sentence "IR causes cell death", where IR is Ionizing Radiation, is instead
+ extracted as "'Insulin Receptor' causes cell death". This would be an example
+ of a grounding error, and although it may happen often enough to provide 
+ large amounts of evidence, it is an extraction error.
+
+The two different levels also have different hashes. At the *pa* level, the 
+hashes discussed [above](#get-hash) are used, as they are calculated from the 
+knowledge contained in the statement, independent of extraction. At the *raw*
+level, a different hash, the `source_hash` is used. Within a statement JSON,
+there is a key "evidence", with a list of Evidence JSON, which includes an 
+entry for "source_hash":
+```python
+{"evidence": [{"source_hash": 98687578576598, ...}, ...], ...}
+```
+Once you know the level ("pa" or "raw"), and you have the correct hash (the 
+shallow pre-assembly hash or the source hash), you can curate a statement by
+POSTing a request with JSON data to the endpoint, as shown in the heading.
 
 
 ## Usage examples

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -1,23 +1,43 @@
 # INDRA Database REST API
 
-One feature of INDRA is the ability to create and maintain a database of
-INDRA Statements. This web API allows accessing Statements in a database by
-searching Statements matching a given set of query paramerters and returning
-the Statements in a JSON serialized form.
+The INDRA Database software has been developed to create and maintain a
+database of text references, content, reading results, and ultimately INDRA
+Statements extracted from those reading results. The software also manages
+the generation and update process of cleaning, deduplicating, and finding
+relations between the raw Statement extractions, into what are called
+pre-assembled Statements. All INDRA Statements can be represented as JSON, 
+which is the format returned by the API.
+
+This web API provides the code necessary to support a REST service which
+allows access to the pre-assembled Statements in a database. The system is
+still under heavy development so capabilities are always expanding, but as
+of this writing, the API supports:
+- `statements/from_agents`, getting Statements by agents, using various ids
+ or names, by statement type (e.g. Phosphorylation), or
+ - `statements/from_hash` and `statements/from_hashes`, getting Statements by
+statement hash, either singly or in batches, and
+- `statements/from_papers`, getting Statements using the paper ids from
+which they were extracted, and
+- `curation/submit/<level>/<hash>` you can also curate Statements, helping us
+improve the quality and accuracy of our content.
+
+As mentioned, the service is changing rapidly, and this documentation may at
+times be out of date. For the latest, check github or contact us.
 
 You need the following information to access a running web service:
 - The address of the web service (below shown with the placeholder
-host.of.api.com)
-- (for some implementations) An API key which needs to be sent in the header of each request to the
+`host.of.api.com`)
+- An API key which needs to be sent in the header of each request to the
 service, or any other credentials that are implemented.
 
 If you want to use our implementation of the web API, you can contact us for
-the path and the API key.
+the path and an API key.
 
-The service in `api.py` is implemented using the Flask Python package.
-The means of hosting this api are left to the user.
-We have had success with [Zappa](https://github.com/Miserlou/Zappa) and AWS,
-and recommend it for a quick and efficient way to get the API up and running.
+The code to support the REST service can be found in `api.py`, implemented
+using the Flask Python package. The means of hosting this api are left to
+the user. We have had success using [Zappa](https://github.com/Miserlou/Zappa)
+and AWS Lambda, and recommend it for a quick and efficient way to get the API
+up and running.
 
 ## Search parameters
 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -60,7 +60,7 @@ options to control the size of the response:
  "false" to get statements in an arbitrary order. This can also speed up a 
  query. You may however find you get a lot of low-quality content.
 
-###<a name="from-agents"></a>Get Statements by Agents (and Type): `api.host/statements/from_agents`
+###<a name="from-agents"></a> Get Statements by Agents (and Type): `api.host/statements/from_agents`
 
 This endpoint allows you to get statements filtering by their agents and 
 the type of Statement. The query parameters are as follows:
@@ -105,7 +105,7 @@ the type of Statement. The query parameters are as follows:
    Note that this field is not case sensitive, so `type=phosphorylation` would
    give the same result.
 
-###<a name="from-hash"></a>Get a Statement and it's Evidence by Hash: `api.host/statements/from_hash`
+###<a name="from-hash"></a> Get a Statement and it's Evidence by Hash: `api.host/statements/from_hash`
 
 ## Usage examples
 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -131,7 +131,7 @@ the type of Statement. The query parameters are as follows:
    give the same result.
 
 <a name="from-hash"></a> 
-### Get a Statement and it's Evidence by hash: `GET api.host/statements/from_hash`
+### Get a Statement by hash: `GET api.host/statements/from_hash`
 
 INDRA Statement objects have a method, `get_hash`, which produces hash from 
 the content of the Statement. A shallow hash only considers the meaning of 
@@ -150,7 +150,7 @@ evidence for a given statement this way. As described above, the evidence
 limit can also be raised, at the risk of a timed out request.
 
 <a name="from-hashes"></a>
-### Get a Statement from many hashes: `POST api.host/statements/from_hashes`
+### Get Statements from many hashes: `POST api.host/statements/from_hashes`
 
 Like the previous endpoint, this endpoint uses hashes to retrieve Statements,
 however instead of only being allowed one at a time, a bach of 
@@ -161,6 +161,22 @@ parameters for this endpoint. The json data should be formatted as:
 {"hashes": [12345, 246810]}
 ```
 with up to 1,000 hashes given in the list.
+
+<a name="from-papers"></a>
+### Get Statements from paper ids: `POST api.host/statements/from_papers`
+
+Using this endpoint, you can pretend you have a fleet of text extraction tools
+that run in seconds! Specifically, you can get the INDRA Statements with 
+evidence from a given list of papers by passing one of the ids of those papers.
+As with the above method, the fact that data (paper ids) is send requires 
+this to be a POST request. The papers ids should be formatted as:
+```json
+{"ids": [{"id": "12345", "type": "pmid"},
+         {"id": "234525", "type": "tcid"},
+         {"id": "PMC23423", "type": "pmcid"}]}
+```
+a list of dicts, each containing id type and and id value.
+
 
 ## Usage examples
 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -85,7 +85,7 @@ JSONs keyed by a shallow statement hash (see [here](#from-hash) for more
 details on these hashes). You can look at the
 [JSON schema](https://github.com/sorgerlab/indra/blob/master/indra/resources/statements_schema.json)
 on github for details on the Statement JSON. To learn more about INDRA
-Statement, you can read the
+Statements, you can read the
 [documentation](https://indra.readthedocs.io/en/latest/modules/statements.html).
 
 <a name="from-agents"></a>
@@ -338,7 +338,7 @@ directly with INDRA tools.
 You can use python to get JSON Statements for the same query:
 ```python
 import requests
-resp = requests.get('https://api.host/statements/from_agents',
+resp = requests.get('http://api.host/statements/from_agents',
                     params={'subject': 'MAP2K1',
                             'object': 'MAPK1',
                             'type': 'phosphorylation',
@@ -380,7 +380,7 @@ from indra.statements import stmts_from_json
 from indra.sources import indra_db_rest as idbr
 
 # With requests
-resp = requests.get('https://api.host/statements/from_agents',
+resp = requests.get('http://api.host/statements/from_agents',
                     params={'agent0': 'SMURF2', 'agent1': 'SMAD',
                             'api_key': 12345, 'max_stmts': 10,
                             'ev_limit': 3})
@@ -392,14 +392,31 @@ stmts = idbr.get_statements(agents=['SMURF2', 'SMAD'], max_stmts=10,
                             ev_limit=3)
 ```
 
-#### Example 3 (curl):
+### Example 3:
+Note the use of the `@FPLX` suffix to denote the namespace used in identifying
+the agent to query for things that inhibit MEK, using curl:
+```bash
+curl -X GET "http://api.host/statements/from_agents?object=MEK@FPLX&type=inhibition&api_key=12345"
+```
+Python requests:
+```python
+resp = requests.get('http://api.host/statements/from_agents',
+                    params={'agent': 'MEK@FPLX', 'type': 'inhibition', 
+                            'api_key': 12345})
+```
+and INDRA's client:
+```python
+stmts = idbr.get_statements(agents=['MEK@FPLX'], stmt_type='inhibition')
+```
+
+#### Example 4:
 Query for a statement with the hash -1072112758478440, retrieving at most 1000
 evidence:
 ```bash
 curl -X GET "http://api.host/statements/from_hash/-1072112758478440?api_key=12345&ev_limit=1000"
 ```
 
-#### Example 4 (curl):
+#### Example 5:
 Get the statements from a paper with the pmid 22174878, and
 another paper with the doi 10.1259/0007-1285-34-407-693, first create the json
 file, call it `papers.json` with the following:

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -392,7 +392,7 @@ stmts = idbr.get_statements(agents=['SMURF2', 'SMAD'], max_stmts=10,
                             ev_limit=3)
 ```
 
-### Example 3:
+#### Example 3:
 Note the use of the `@FPLX` suffix to denote the namespace used in identifying
 the agent to query for things that inhibit MEK, using curl:
 ```bash
@@ -411,10 +411,16 @@ stmts = idbr.get_statements(agents=['MEK@FPLX'], stmt_type='inhibition')
 
 #### Example 4:
 Query for a statement with the hash -1072112758478440, retrieving at most 1000
-evidence:
+evidence, using curl:
 ```bash
 curl -X GET "http://api.host/statements/from_hash/-1072112758478440?api_key=12345&ev_limit=1000"
 ```
+or INDRA's client:
+```python
+stmts = idbr.get_statements_by_hash([-1072112758478440], ev_limit=1000)
+```
+Note that client does not actually use the same endpoint here, but rather uses
+the `/from_hashes` endpoint.
 
 #### Example 5:
 Get the statements from a paper with the pmid 22174878, and
@@ -430,5 +436,22 @@ file, call it `papers.json` with the following:
 ```
 and post it to the REST API with curl:
 ```bash
-curl -X POST "http://api.host/statements/from_papers?api_key=12345" -H "Content-Type: application/json" -d @papers.json
+curl -X POST "http://api.host/statements/from_papers?api_key=12345" -d @papers.json -H "Content-Type: application/json"
+```
+or just use INDRA's client:
+```python
+stmts = idbr.get_statments_for_paper([('pmid', '22174878'),
+                                      ('doi', '10.1259/0007-1285-34-407-693')])
+```
+
+#### Example 6:
+Curate a Statement at the pre-assembled (pa) level for a Statement with hash
+-1072112758478440, using curl:
+```bash
+curl -X POST "http://api.host/curation/submit/pa/-1072112758478440?api_key=12345" -d '{"tag": "correct", "text": "This Statement is OK.", "curator": "Alice"}' -H "Content-Type: application/json"
+```
+or INDRA's client:
+```python
+idbr.submit_curation('pa', -1072112758478440, 'correct', 
+                     'This Statement is OK.', 'Alice')
 ```

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -48,11 +48,11 @@ options to control the size of the response:
 - **`max_stmts`**: Set the maximum number of statements you wish to receive.
  The REST API maximum is 1000, which cannot be overridden by this argument
  (to prevent request timeouts).
-- **`ev_limit`**: By default, only 10 pieces of Evidence will be included
- with each statement. A single statement can have upwards of 10,000 pieces of
- evidence, so this allows queries to be run reliably. There is no limitation
- on this value, so use with caution. Setting too high a value may cause a 
- request to time or be too large to return.
+- **`ev_limit`**: The default varies, but in general the amount of Evidence 
+ returned for each statement is limited. A single statement can have upwards of
+ 10,000 pieces of evidence, so this allows queries to be run reliably. There
+ is no limitation on this value, so use with caution. Setting too high a value
+ may cause a request to time out or be too large to return.
 - **`best_first`**: This is set to "true" by default, so statements with the
  most evidence are returned first. These are generally the most reliable, 
  however they are also generally the most canonical. Set this parameter to 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -12,8 +12,8 @@ This web API provides the code necessary to support a REST service which
 allows access to the pre-assembled Statements in a database. The system is
 still under heavy development so capabilities are always expanding, but as
 of this writing, the API supports:
-- `statements/from_agents`, getting Statements by agents, using various ids
- or names, by statement type (e.g. Phosphorylation), or
+- [`statements/from_agents`](#from-agents), getting Statements by agents, using
+various ids or names, by statement type (e.g. Phosphorylation), or
  - `statements/from_hash` and `statements/from_hashes`, getting Statements by
 statement hash, either singly or in batches, and
 - `statements/from_papers`, getting Statements using the paper ids from
@@ -26,7 +26,7 @@ times be out of date. For the latest, check github or contact us.
 
 You need the following information to access a running web service:
 - The address of the web service (below shown with the placeholder
-`host.of.api.com`)
+`api.host`)
 - An API key which needs to be sent in the header of each request to the
 service, or any other credentials that are implemented.
 
@@ -39,52 +39,73 @@ the user. We have had success using [Zappa](https://github.com/Miserlou/Zappa)
 and AWS Lambda, and recommend it for a quick and efficient way to get the API
 up and running.
 
-## Search parameters
+## The Endpoints
 
-The API accepts requests to retrieve serialized INDRA Statements
-from a database according to various search criteria. You can specify
-the agent arguments as well as the type of Statement of interest. 
-The query parameters available are as follows:
+For all queries, an API key is required, which is passed as a parameter
+`api-key` to any/all queries. Below is detailed documentation for the
+different endpoints of the API. In addition, all endpoints that return
+statements (i.e. those with the root `/statements`), have the following
+options to control the size of the response:
+- **`max_stmts`**: Set the maximum number of statements you wish to receive.
+ The REST API maximum is 1000, which cannot be overridden by this argument
+ (to prevent request timeouts).
+- **`ev_limit`**: By default, only 10 pieces of Evidence will be included
+ with each statement. A single statement can have upwards of 10,000 pieces of
+ evidence, so this allows queries to be run reliably. There is no limitation
+ on this value, so use with caution. Setting too high a value may cause a 
+ request to time or be too large to return.
+- **`best_first`**: This is set to "true" by default, so statements with the
+ most evidence are returned first. These are generally the most reliable, 
+ however they are also generally the most canonical. Set this parameter to 
+ "false" to get statements in an arbitrary order. This can also speed up a 
+ query. You may however find you get a lot of low-quality content.
+
+###<a name="from-agents"></a>Get Statements by Agents (and Type): `api.host/statements/from_agents`
+
+This endpoint allows you to get statements filtering by their agents and 
+the type of Statement. The query parameters are as follows:
 - **`subject`**, **`object`**: The HGNC gene symbol of the subject or
-object of the Statement.
-**Note**: only one of each of `subject` and `object` will be accepted per
-query.
+ object of the Statement. **Note**: only one of each of `subject` and 
+ `object` will be accepted per query.
   - Example 1: if looking for Statements where MAP2K1 is a subject
-(e.g. "What does MAP2K1 phosphorylate?"), specify
-`subject=MAP2K1` as a query parameter
+   (e.g. "What does MAP2K1 phosphorylate?"), specify `subject=MAP2K1` as a 
+   query parameter
   - Example 2: if looking for Statements where MAP2K1 is the subject and
-MAPK1 is the object, add both `subject=MAP2K1` and `object=MAPK1` as
-query parameters.
+   MAPK1 is the object, add both `subject=MAP2K1` and `object=MAPK1` as
+   query parameters.
   - Example 3: you can specify the agent id namespace by appending
-  `@<namespace>` to the agent id in the parameter, e.g.
-  `subject=6871@HGNC`.
+   `@<namespace>` to the agent id in the parameter, e.g. `subject=6871@HGNC`.
+
 - **`agent*`**: This parameter is used if the specific role of the agent
-(subject or object) is irrelevant, or the distinction doesn't apply to the
-type of Statement of interest (e.g. Complex, Translocation, ActiveForm).
-**Note**: You can include as many `agent*` queries as you like, however you
-will only get Statements that include all agents you query, in addition to
-those queried for `subject` and `object`. Furthermore, to include multiple
-agents on our particular implementation, which uses the AWS API Gateway,
-you must include a suffix to each agent key, such as `agent0` and `agent1`,
-or else all but one agent will be stripped out. Note that you need not use
-integers, you can add any suffix you like, e.g. `agentOfDestruction=TP53`
-would be entirely valid.
+ (subject or object) is irrelevant, or the distinction doesn't apply to the
+ type of Statement of interest (e.g. Complex, Translocation, ActiveForm).
+ **Note**: You can include as many `agent*` queries as you like, however you
+ will only get Statements that include all agents you query, in addition to
+ those queried for `subject` and `object`. Furthermore, to include multiple
+ agents on our particular implementation, which uses the AWS API Gateway,
+ you must include a suffix to each agent key, such as `agent0` and `agent1`,
+ or else all but one agent will be stripped out. Note that you need not use
+ integers, you can add any suffix you like, e.g. `agentOfDestruction=TP53`
+ would be entirely valid.
   - Example 1: To obtain Statements that involve SMAD2 in any role, add
-  `agent=SMAD2` to the query.
+   `agent=SMAD2` to the query.
   - Example 2: As with `subject` and `object`, you can specify the
-  namespace for an agent by appending `@<namespace>` to the agent's id, e.g.
-  `agent=ERK@TEXT`.
+   namespace for an agent by appending `@<namespace>` to the agent's id, e.g.
+   `agent=ERK@TEXT`.
   - Example 3: If you wanted to query multiple statements, you could include
-  `agent0=MEK@FPLX` and `agent1=ERK@FPLX`. Note that the value of the
+   `agent0=MEK@FPLX` and `agent1=ERK@FPLX`. Note that the value of the
    integers has no real bearing on the ordering, and only serves to make the
-    agents uniquely keyed. Thus `agent1=MEK@FPLX` and `agent0=ERK@FPLX` will
-     give exactly the same result.
+   agents uniquely keyed. Thus `agent1=MEK@FPLX` and `agent0=ERK@FPLX` will
+   give exactly the same result.
+
 - **`type`**: This parameter can be used to specify what type of Statement
-of interest (e.g. Phosphorylation, Activation, Complex).
+ of interest (e.g. Phosphorylation, Activation, Complex).
   - Example: To answer the question "Does MAP2K1 phosphorylate MAPK1?"
-the parameter `type=Phosphorylation` can be included in your query.
-Note that this field is not case sensitive, so `type=phosphorylation` would
-give the same result.
+   the parameter `type=Phosphorylation` can be included in your query.
+   Note that this field is not case sensitive, so `type=phosphorylation` would
+   give the same result.
+
+###<a name="from-hash"></a>Get a Statement and it's Evidence by Hash: `api.host/statements/from_hash`
 
 ## Usage examples
 
@@ -95,7 +116,7 @@ use of API keys which have to be included in the request header. Here we
 provide usage examples with the `curl` command line tool and `python`.
 
 In the examples, let's assume the path to the web API is
-`https://host.of.api.com/`, and that the API key is `12345`.
+`https://api.host/`, and that the API key is `12345`.
 
 ### Curl
 `curl` is a command line tool on Linux and Mac, making it a convenient tool
@@ -104,7 +125,7 @@ for making calls to this web API.
 Example 1: Using `curl`, a query for "MAP2K1 phophorylates MAPK1" can be sent
 as:
 ```bash
-curl -i -H "x-api-key:12345" -X GET "https://host.of.api.com/statements/?subject=MAP2K1&object=MAPK1&type=phosphorylation"
+curl -i -H "x-api-key:12345" -X GET "https://api.host/statements/?subject=MAP2K1&object=MAPK1&type=phosphorylation"
 ```
 which will return a JSON list of Statements. Note that if there is no API key,
 you can simply remove `-H "x-api-key:12345"` from the command.
@@ -113,13 +134,13 @@ Example 2: If we instead want to know if there is any support for the
 proposition there is some kind of interaction between SMURF2 and SMAD2,
 your `curl` query would be:
 ```bash
-curl -i -H "x-api-key:12345" -X GET "https://host.of.api.com/statements/?
+curl -i -H "x-api-key:12345" -X GET "https://api.host/statements/?
 agent=SMURF2&agent=SMAD2"
 ```
 Or, if you are using our implementation of the REST service, you would
 need to use
 ```bash
-curl -i -H "x-api-key:12345" -X GET "https://host.of.api.com/statements/?
+curl -i -H "x-api-key:12345" -X GET "https://api.host/statements/?
 agent0=SMURF2&agentbondjamesbond=SMAD2"
 ```
 
@@ -132,7 +153,7 @@ relevant for "MEK phosphorylates ERK", you can get the Statement JSONs
 as follows:
 ```python
 import requests
-resp = requests.get('https://host.of.api.com/statements/',
+resp = requests.get('https://api.host/statements/',
                     headers={'x-api-key': '12345'},
                     params={'subject': 'MAP2K1',
                             'object': 'MAPK1',
@@ -160,7 +181,7 @@ be represented with a Python `dict` as was used in the previous example.
 The agent arguments can be set directly as a string in the `params`
 keyword argument:
 ```python
-resp = requests.get('https://host.of.api.com/statements/',
+resp = requests.get('https://api.host/statements/',
                     headers={'x-api-key': '12345'},
                     params=u'agent0=SMAD2&agent1=SMURF2')
 ```
@@ -181,6 +202,6 @@ resolve queries that result in large amounts of content.
 ### Browser
 You can only use a browser if there is no API key required to use the API.
 If that is the case, you can simply enter the link:
-`https://host.of.api.com/statements/?subject=MAP2K1&object=MAPK1`
+`https://api.host/statements/?subject=MAP2K1&object=MAPK1`
 into your browser's address bar to ge the JSON response which can
 be saved.

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -82,7 +82,11 @@ numbers):
 ```
 where the `"statements"` element contains a dictionary of INDRA Statement
 JSONs keyed by a shallow statement hash (see [here](#from-hash) for more
-details on these hashes).
+details on these hashes). You can look at the
+[JSON schema](https://github.com/sorgerlab/indra/blob/master/indra/resources/statements_schema.json)
+on github for details on the Statement JSON. To learn more about INDRA Statement,
+you can read the
+[documentation](https://indra.readthedocs.io/en/latest/modules/statements.html).
 
 <a name="from-agents"></a>
 ### Get Statements by agents (and type): `GET api.host/statements/from_agents`
@@ -214,7 +218,7 @@ curating the piece of knowledge, or a particular extraction. This is the
  large amounts of evidence, it is an extraction error.
 
 The two different levels also have different hashes. At the *pa* level, the 
-hashes discussed [above](#get-hash) are used, as they are calculated from the 
+hashes discussed [above](#from-hash) are used, as they are calculated from the 
 knowledge contained in the statement, independent of extraction. At the *raw*
 level, a different hash, the `source_hash` is used. Within a statement JSON,
 there is a key "evidence", with a list of Evidence JSON, which includes an 

--- a/rest_api/README.md
+++ b/rest_api/README.md
@@ -84,8 +84,8 @@ where the `"statements"` element contains a dictionary of INDRA Statement
 JSONs keyed by a shallow statement hash (see [here](#from-hash) for more
 details on these hashes). You can look at the
 [JSON schema](https://github.com/sorgerlab/indra/blob/master/indra/resources/statements_schema.json)
-on github for details on the Statement JSON. To learn more about INDRA Statement,
-you can read the
+on github for details on the Statement JSON. To learn more about INDRA
+Statement, you can read the
 [documentation](https://indra.readthedocs.io/en/latest/modules/statements.html).
 
 <a name="from-agents"></a>
@@ -93,7 +93,7 @@ you can read the
 
 This endpoint allows you to get statements filtering by their agents and 
 the type of Statement. The query parameters are as follows:
-- **`subject`**, **`object`**: The HGNC gene symbol of the subject or
+- **subject**, **object**: The HGNC gene symbol of the subject or
  object of the Statement. **Note**: only one of each of `subject` and 
  `object` will be accepted per query.
   - Example 1: if looking for Statements where MAP2K1 is a subject
@@ -105,7 +105,7 @@ the type of Statement. The query parameters are as follows:
   - Example 3: you can specify the agent id namespace by appending
    `@<namespace>` to the agent id in the parameter, e.g. `subject=6871@HGNC`.
 
-- **`agent*`**: This parameter is used if the specific role of the agent
+- **agent***: This parameter is used if the specific role of the agent
  (subject or object) is irrelevant, or the distinction doesn't apply to the
  type of Statement of interest (e.g. Complex, Translocation, ActiveForm).
  **Note**: You can include as many `agent*` queries as you like, however you
@@ -127,7 +127,7 @@ the type of Statement. The query parameters are as follows:
    agents uniquely keyed. Thus `agent1=MEK@FPLX` and `agent0=ERK@FPLX` will
    give exactly the same result.
 
-- **`type`**: This parameter can be used to specify what type of Statement
+- **type**: This parameter can be used to specify what type of Statement
  of interest (e.g. Phosphorylation, Activation, Complex).
   - Example: To answer the question "Does MAP2K1 phosphorylate MAPK1?"
    the parameter `type=Phosphorylation` can be included in your query.
@@ -207,7 +207,7 @@ pre-assembly algorithms.
 If you wish to curate a Statement, you must first decide whether you are
 curating the Statement as generally incorrect, or whether a particular
 sentence supports a given Statement. This is the "level" of your curation:
-- **pa**: At this level, you are curating the knowledge in a
+- __pa__: At this level, you are curating the knowledge in a
  ***p**re-**a**ssembled* Statement. For example, if a Statement
  indicates that "differentiation binds apoptosis", regardless of whether the
  reader(s) made a valid extraction, it is clearly wrong.
@@ -217,23 +217,33 @@ sentence supports a given Statement. This is the "level" of your curation:
  Statement. For example the (hypothetical) sentence "KRAS was found to actively
  inhibit BRAF" does not support the Statement "KRAS activates BRAF". As another
  example (here a grounding error), would be that the sentence "IR causes cell
- death", where IR is Ionizing Radiation does not support the extraction "'Insulin
- Receptor' causes cell death".
+ death", where IR is Ionizing Radiation does not support the extraction
+ "'Insulin Receptor' causes cell death".
 
 The two different levels also have different hashes. At the *pa* level, the 
 hashes discussed [above](#from-hash) are used, as they are calculated from the 
 knowledge contained in the statement, independent of the evidence. At the *raw*
 level, a different hash, the `source_hash` is used, which identifies a specific
-piece of evidence, without considering the Statement extracted. Within a statement
-JSON, there is a key "evidence", with a list of Evidence JSON, which includes an 
-entry for "source_hash":
+piece of evidence, without considering the Statement extracted. Within a
+Statement JSON, there is a key "evidence", with a list of Evidence JSON, which
+includes an entry for "source_hash":
 ```python
 {"evidence": [{"source_hash": 98687578576598, ...}, ...], ...}
 ```
 Once you know the level ("pa" or "raw"), and you have the correct hash (the 
 shallow pre-assembly hash or the source hash), you can curate a statement by
-POSTing a request with JSON data to the endpoint, as shown in the heading.
-
+POSTing a request with JSON data to the endpoint, as shown in the heading. The
+JSON data should contain the following fields:
+- **tag**: A very short word or phrase categorizing the error, for example 
+ "grounding" for a grounding error.
+- **text**: A brief description of what you think is most wrong.
+- **curator**: Your name, initials, email, or other way to identify yourself.
+ Whichever you choose, please be consistent.
+ 
+Note that you can also indicate that a Statement is _correct_. In particular,
+if you find that a Statement has some evidence that supports the Statement and
+some that does not, curating examples of both is valuable. In general, flagging
+correct Statements can be just as valuable as flagging incorrect Statements.
 
 ## Usage examples
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -88,7 +88,9 @@ def _query_wrapper(f):
         query = request.args.copy()
         offs = query.pop('offset', None)
         ev_lim = query.pop('ev_limit', 10)
-        best_first = query.pop('best_first', True)
+        best_first_str = query.pop('best_first', 'true')
+        best_first = True if best_first_str.lower() == 'true' \
+                             or best_first_str else False
         do_stream_str = query.pop('stream', 'false')
         do_stream = True if do_stream_str == 'true' else False
         max_stmts = min(int(query.pop('max_stmts', MAX_STATEMENTS)),

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -271,12 +271,19 @@ def get_paper_statements(query_dict, offs, max_stmts, ev_limit, best_first):
         abort(Response("No ids in request!", 400))
 
     # Format the ids.
-    ids_inp = [(typ, int(val) if typ in ['trid', 'tcid'] else val)
-               for val, typ in ids.items()]
+    id_tpls = set()
+    for id_dict in ids:
+        val = id_dict['id']
+        typ = id_dict['type']
+
+        # Turn tcids and trids into integers.
+        id_val = int(val) if typ in ['tcid', 'trid'] else val
+
+        id_tpls.add((typ, id_val))
 
     # Now get the statements.
-    logger.info('Getting statements for %d papers.' % len(ids_inp))
-    result = get_statement_jsons_from_papers(ids_inp, max_stmts=max_stmts,
+    logger.info('Getting statements for %d papers.' % len(id_tpls))
+    result = get_statement_jsons_from_papers(id_tpls, max_stmts=max_stmts,
                                              offset=offs, ev_limit=ev_limit,
                                              best_first=best_first)
     return result

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -87,7 +87,7 @@ def _query_wrapper(f):
 
         query = request.args.copy()
         offs = query.pop('offset', None)
-        ev_lim = query.pop('ev_limit', 10)
+        ev_lim = query.pop('ev_limit', None)
         best_first_str = query.pop('best_first', 'true')
         best_first = True if best_first_str.lower() == 'true' \
                              or best_first_str else False
@@ -171,6 +171,8 @@ def get_statements_query_format():
 def get_statements(query_dict, offs, max_stmts, ev_limit, best_first):
     """Get some statements constrained by query."""
     logger.info("Getting query details.")
+    if ev_limit is None:
+        ev_limit = 10
     try:
         # Get the agents without specified locations (subject or object).
         free_agents = [__process_agent(ag)
@@ -193,11 +195,11 @@ def get_statements(query_dict, offs, max_stmts, ev_limit, best_first):
     # Fix the case, if we got a statement type.
     act = None if act_raw is None else make_statement_camel(act_raw)
 
-    # If there was something else in the query, there shouldn't be, so someone's
-    # probably confused.
+    # If there was something else in the query, there shouldn't be, so
+    # someone's probably confused.
     if query_dict:
-        abort(Response("Unrecognized query options; %s." % list(query_dict.keys()),
-                       400))
+        abort(Response("Unrecognized query options; %s."
+                       % list(query_dict.keys()), 400))
         return
 
     # Make sure we got SOME agents. We will not simply return all
@@ -226,7 +228,9 @@ def get_statements(query_dict, offs, max_stmts, ev_limit, best_first):
 
 @app.route('/statements/from_hashes', methods=['POST'])
 @_query_wrapper
-def get_statements_by_hashes(query_dict, offs, max_stmts, ev_limit, best_first):
+def get_statements_by_hashes(query_dict, offs, max_stmts, ev_lim, best_first):
+    if ev_lim is None:
+        ev_lim = 20
     hashes = request.json.get('hashes')
     if not hashes:
         logger.error("No hashes provided!")
@@ -237,7 +241,7 @@ def get_statements_by_hashes(query_dict, offs, max_stmts, ev_limit, best_first):
                        400))
 
     result = get_statement_jsons_from_hashes(hashes, max_stmts=max_stmts,
-                                             offset=offs, ev_limit=ev_limit,
+                                             offset=offs, ev_limit=ev_lim,
                                              best_first=best_first)
     return result
 
@@ -246,7 +250,8 @@ def get_statements_by_hashes(query_dict, offs, max_stmts, ev_limit, best_first):
 @_query_wrapper
 def get_statement_by_hash(query_dict, offs, max_stmts, ev_limit, best_first,
                           hash_val):
-    ev_limit = 10000
+    if ev_limit is None:
+        ev_limit = 10000
     return get_statement_jsons_from_hashes([hash_val], max_stmts=max_stmts,
                                            offset=offs, ev_limit=ev_limit,
                                            best_first=best_first)

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -96,7 +96,7 @@ def _query_wrapper(f):
         max_stmts = min(int(query.pop('max_stmts', MAX_STATEMENTS)),
                         MAX_STATEMENTS)
 
-        api_key = query.pop('api-key', None)
+        api_key = query.pop('api_key', None)
 
         logger.info("Running function %s after %s seconds."
                     % (f.__name__, sec_since(start_time)))

--- a/rest_api/test_api.py
+++ b/rest_api/test_api.py
@@ -330,9 +330,9 @@ class DbApiTestCase(unittest.TestCase):
         return
 
     def __test_basic_paper_query(self, id_val, id_type, min_num_results=1):
-        query_str = 'id=%s&type=%s' % (id_val, id_type)
-        resp, dt, size = self.__time_get_query('statements/from_papers',
-                                               query_str)
+        id_list = [{'id': id_val, 'type': id_type}]
+        resp, dt, size = self.__time_query('post', 'statements/from_papers',
+                                           ids=id_list)
         self.__check_time(dt)
         assert size <= SIZELIMIT, size
         assert resp.status_code == 200, str(resp)
@@ -345,11 +345,6 @@ class DbApiTestCase(unittest.TestCase):
     def test_pmid_paper_query(self):
         pmid = '27014235'
         self.__test_basic_paper_query(pmid, 'pmid')
-
-        # Now check without pmid specified (should be assumed.)
-        resp, _, _ = self.__time_get_query('statements/from_papers',
-                                           'id=%s' % pmid)
-        assert resp.status_code == 200, str(resp)
 
     def test_pmcid_paper_query(self):
         json_dict = self.__test_basic_paper_query('PMC5770457', 'pmcid')
@@ -414,8 +409,9 @@ class DbApiTestCase(unittest.TestCase):
                                      'agent1=STAT5@FPLX&agent2=CRKL')
 
     def test_redaction_on_paper_query(self):
-        return self.__test_redaction('get', 'statements/from_papers',
-                                     'id=20914619&type=tcid')
+        ids = [{'id': '20914619', 'type': 'tcid'}]
+        return self.__test_redaction('post', 'statements/from_papers', None,
+                                     url_fmt='%s?%s', ids=ids)
 
     def test_redaction_on_hash_query(self):
         sample_hashes = [


### PR DESCRIPTION
This is essentially a complete rewrite of the documentation for the REST API, which was months out of date. This PR also:
- Allowed Statements from multiple papers to be queried in a single request (addressed a long standing issue not tracked on this repo)
- Changes the `api-key` parameter to `api_key` to match the underscore convention used by all the other parameters.
- Improves the default evidence limits to vary appropriately between endpoints.