### PR TITLE
Fix a bug in retrieving pa statements without evidence.

### DIFF
--- a/indra_db/client/statements.py
+++ b/indra_db/client/statements.py
@@ -260,7 +260,7 @@ def get_statements(clauses, count=1000, do_stmt_count=False, db=None,
         else:
             # Get just pa statements without their supporting raw statement(s).
             pa_stmts = db.select_all(db.PAStatements, *clauses, yield_per=cnt)
-            stmt_dict = _process_pa_statement_res_nev(db, pa_stmts, count=cnt)
+            stmt_dict = _process_pa_statement_res_nev(pa_stmts, count=cnt)
 
         # Populate the supports/supported by fields.
         if with_support:

--- a/indra_db/client/statements.py
+++ b/indra_db/client/statements.py
@@ -101,8 +101,9 @@ def get_statements_by_gene_role_type(agent_id=None, agent_ns='HGNC-SYMBOL',
             return []
         agent_ns = 'HGNC'
     agent_id = regularize_agent_id(agent_id, agent_ns)
-    clauses.extend([Agents.db_name.like(agent_ns),
-                    Agents.db_id.like(agent_id)])
+    if agent_id and agent_ns:
+        clauses.extend([Agents.db_name.like(agent_ns),
+                        Agents.db_id.like(agent_id)])
     if role:
         clauses.append(Agents.role == role)
     if agent_id or role:

--- a/indra_db/tests/test_client.py
+++ b/indra_db/tests/test_client.py
@@ -203,6 +203,15 @@ def test_get_statements_by_grot():
 
 
 @attr('nonpublic')
+def test_get_statments_grot_wo_evidence():
+    num_stmts = 1000
+    db, _ = _get_prepped_db(num_stmts)
+
+    stmts = dbc.get_statements_by_gene_role_type('MAP2K1', with_evidence=False)
+    assert stmts, stmts
+
+
+@attr('nonpublic')
 def test_get_content_by_refs():
     db, _ = _get_prepped_db(100)
     tcid = db.select_one(db.TextContent.id)[0]


### PR DESCRIPTION
Fix a long-standing bug preventing user from getting statements directly from the database without evidence.