### PR TITLE
Add setup and simplify Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,8 @@ python:
 before_install:
   - sudo apt-get update
 install:
-  # Packages needed for testing
-  - pip install nose coverage python-coveralls nose-timer
-  # INDRA dependencies
-  - pip install git+https://github.com/sorgerlab/indra.git
   # INDRA-DB dependencies
-  - pip install .
+  - pip install .[test] --process-dependency-links --allow-all-external
   # DB Preassembly pickles
   - cd $TRAVIS_BUILD_DIR/indra_db/tests
   - wget http://sorger.med.harvard.edu/data/bgyori/test_text_ref_tuples.pkl -nv

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - pip install nose coverage python-coveralls nose-timer
   # INDRA-DB dependencies
   - pip install boto3 sqlalchemy psycopg2-binary pgcopy flask nltk reportlab
+        matplotlib
   # INDRA dependencies
   - pip install git+https://github.com/sorgerlab/indra.git
   # DB Preassembly pickles
@@ -42,8 +43,7 @@ script:
   # Now run all INDRA_DB tests
   - nosetests indra_db -v -a $NOSEATTR
         --with-coverage --cover-inclusive --cover-package=indra
-        --with-doctest --with-doctest-ignore-unicode
-        --with-timer --timer-top-n 10
+        --with-doctest --with-timer --timer-top-n 10
   - cd $TRAVIS_BUILD_DIR
   # Run code style report on diff
   - git remote set-branches --add origin master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ python:
 before_install:
   - sudo apt-get update
 install:
+  - pip install git+https://github.com/sorgerlab/indra.git
   # INDRA-DB dependencies
-  - pip install .[test] --process-dependency-links --allow-all-external
+  - pip install .[test]
   # DB Preassembly pickles
   - cd $TRAVIS_BUILD_DIR/indra_db/tests
   - wget http://sorger.med.harvard.edu/data/bgyori/test_text_ref_tuples.pkl -nv

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,10 @@ before_install:
 install:
   # Packages needed for testing
   - pip install nose coverage python-coveralls nose-timer
-  # INDRA-DB dependencies
-  - pip install boto3 sqlalchemy psycopg2-binary pgcopy flask nltk reportlab
-        matplotlib
   # INDRA dependencies
   - pip install git+https://github.com/sorgerlab/indra.git
+  # INDRA-DB dependencies
+  - pip install .
   # DB Preassembly pickles
   - cd $TRAVIS_BUILD_DIR/indra_db/tests
   - wget http://sorger.med.harvard.edu/data/bgyori/test_text_ref_tuples.pkl -nv

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,12 @@ python:
   - "3.6"
 before_install:
   - sudo apt-get update
-  - pip install numpy scipy sympy cython nose lxml matplotlib==1.5.0 pandas
-  - sudo pip2 install numpy
 install:
+  # Packages needed for testing
+  - pip install nose coverage python-coveralls nose-timer
+  # INDRA-DB dependencies
+  - pip install boto3 sqlalchemy psycopg2-binary pgcopy flask nltk reportlab
   # INDRA dependencies
-  - pip install coverage python-coveralls boto3 sqlalchemy psycopg2-binary pgcopy nose-timer flask nltk reportlab
-  - pip install git+https://github.com/bgyori/paths_graph.git@networkx2
-  - pip install doctest-ignore-unicode
   - pip install git+https://github.com/sorgerlab/indra.git
   # DB Preassembly pickles
   - cd $TRAVIS_BUILD_DIR/indra_db/tests
@@ -22,7 +21,6 @@ install:
   - wget http://sorger.med.harvard.edu/data/bgyori/test_reading_tuples.pkl -nv
   - wget http://sorger.med.harvard.edu/data/bgyori/test_db_info_tuples.pkl -nv
   - wget http://sorger.med.harvard.edu/data/bgyori/test_stmts_tuples.pkl -nv
-  - pip install -U networkx>=2
   - pip list
 before_script:
   # Enable plotting on fake display

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,11 @@ def main():
           long_description='INDRA Database',
           url='https://github.com/indralab/indra_db',
           packages=find_packages(),
-          install_requires=['boto3', 'sqlalchemy', 'psycopg2-binary',
+          install_requires=['indra', 'boto3', 'sqlalchemy', 'psycopg2-binary',
                             'pgcopy', 'matplotlib', 'flask', 'nltk',
                             'reportlab'],
           extras_require={'test': ['nose', 'coverage', 'python-coveralls',
                                    'nose-timer']},
-          dependency_links=['git+https://github.com/sorgerlab/indra.git']
           )
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,3 +12,7 @@ def main():
                             'pgcopy', 'matplotlib', 'flask', 'nltk',
                             'reportlab']
           )
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ def main():
           packages=find_packages(),
           install_requires=['boto3', 'sqlalchemy', 'psycopg2-binary',
                             'pgcopy', 'matplotlib', 'flask', 'nltk',
-                            'reportlab']
+                            'reportlab'],
+          extras_require={'test': ['nose', 'coverage', 'python-coveralls',
+                                   'nose-timer']},
+          dependency_links=['git+https://github.com/sorgerlab/indra.git']
           )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+import sys
+from setuptools import setup, find_packages
+
+def main():
+    setup(name='indra_db',
+          version='0.0.1',
+          description='INDRA Database',
+          long_description='INDRA Database',
+          url='https://github.com/indralab/indra_db',
+          packages=find_packages()
+          install_requires=['boto3', 'sqlalchemy', 'psycopg2-binary',
+                            'pgcopy', 'matplotlib', 'flask', 'nltk',
+                            'reportlab']
+          )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def main():
           description='INDRA Database',
           long_description='INDRA Database',
           url='https://github.com/indralab/indra_db',
-          packages=find_packages()
+          packages=find_packages(),
           install_requires=['boto3', 'sqlalchemy', 'psycopg2-binary',
                             'pgcopy', 'matplotlib', 'flask', 'nltk',
                             'reportlab']


### PR DESCRIPTION
This PR adds a simple setup.py to make the package installable as a dependency. It also simplifies .travis.yml to remove any redundant dependencies, and install all regular and test dependencies via setup.py.