### PR TITLE
Improve handling of reading duplicates

### DIFF
--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -237,6 +237,7 @@ class DatabaseManager(object):
 
         class Updates(self.Base, Displayable):
             __tablename__ = 'updates'
+            _skip_disp = ['unresolved_conflicts_file']
             id = Column(Integer, primary_key=True)
             init_upload = Column(Boolean, nullable=False)
             source = Column(String(250), nullable=False)
@@ -327,14 +328,33 @@ class DatabaseManager(object):
             json = Column(Bytea, nullable=False)
             create_date = Column(DateTime, default=func.now())
             __table_args__ = (
-                UniqueConstraint('mk_hash', 'text_hash', 'source_hash',
-                                 'reading_id',
+                UniqueConstraint('mk_hash', 'text_hash', 'reading_id',
                                  name='reading_raw_statement_uniqueness'),
                 UniqueConstraint('mk_hash', 'source_hash', 'db_info_id',
                                  name='db_info_raw_statement_uniqueness'),
                 )
         self.RawStatements = RawStatements
         self.tables[RawStatements.__tablename__] = RawStatements
+
+        class RejectedStatements(self.Base, Displayable):
+            __tablename__ = 'rejected_statements'
+            _skip_disp = ['json']
+            id = Column(Integer, primary_key=True)
+            uuid = Column(String(40), unique=True, nullable=False)
+            batch_id = Column(Integer, nullable=False)
+            mk_hash = Column(BigInteger, nullable=False)
+            text_hash = Column(BigInteger)
+            source_hash = Column(BigInteger, nullable=False)
+            db_info_id = Column(Integer, ForeignKey('db_info.id'))
+            db_info = relationship(DBInfo)
+            reading_id = Column(Integer, ForeignKey('reading.id'))
+            reading = relationship(Reading)
+            type = Column(String(100), nullable=False)
+            indra_version = Column(String(100), nullable=False)
+            json = Column(Bytea, nullable=False)
+            create_date = Column(DateTime, default=func.now())
+        self.RejectedStatements = RejectedStatements
+        self.tables[RejectedStatements.__tablename__] = RejectedStatements
 
         class RawAgents(self.Base, Displayable):
             __tablename__ = 'raw_agents'

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -416,12 +416,18 @@ class DatabaseReader(object):
                     len(self.statement_outputs))
         batch_id = self._db.make_copy_batch_id()
         stmt_tuples = {}
+        dups = {}
         for s in self.statement_outputs:
             tpl = s.make_tuple(batch_id)
-            key = (tpl[1], tpl[4], tpl[5], tpl[9])
+            key = (tpl[1], tpl[4], tpl[9])
             if key in stmt_tuples.keys():
                 logger.warning('Duplicate key found: %s.' % str(key))
-            stmt_tuples[key] = tpl
+                if key in dups.keys():
+                    dups[key].append(tpl)
+                else:
+                    dups[key] = [tpl, stmt_tuples[key]]
+            else:
+                stmt_tuples[key] = tpl
         self._db.copy('raw_statements', stmt_tuples.values(),
                       DatabaseStatementData.get_cols(), lazy=True,
                       push_conflict=True,


### PR DESCRIPTION
Make the criteria for uniqueness of statements from reading stricter, but also keep the statements that are deemed "duplicates" in a separate table. These can be examined later, and matched to "accepted" statements in the raw statements table using text hashes, matches key hashes, and the batch ids.