### PR TITLE
Allow queries of 3+ agents

### DIFF
--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -203,7 +203,9 @@ def get_statement_jsons_from_agents(agents=None, stmt_type=None, db=None,
         queries.append(q)
     assert queries, "No conditions imposed."
 
-    mk_hashes_q = intersect_all(*queries)
+    mk_hashes_q = (db.session
+                   .query('mk_hash', 'ev_count')
+                   .filter(intersect_all(*queries)))
 
     return _get_pa_stmt_jsons_w_mkhash_subquery(db, mk_hashes_q, **kwargs)
 

--- a/indra_db/tests/test_client.py
+++ b/indra_db/tests/test_client.py
@@ -327,6 +327,16 @@ def test_nfkb_anomaly():
 
 
 @attr('nonpublic')
+def test_triple_agent_bug():
+    agents = [(None, '1834', 'HGNC'), (None, '6769', 'HGNC'),
+              (None, '12856', 'HGNC')]
+    res = dbc.get_statement_jsons_from_agents(agents=agents, max_stmts=100,
+                                              stmt_type='Complex',
+                                              ev_limit=5)
+    assert res
+
+
+@attr('nonpublic')
 def test_null_response():
     res = dbc.get_statement_jsons_from_hashes([0])
     assert isinstance(res, dict), type(res)


### PR DESCRIPTION
Refactor handling of multiple constraints to handle 3+ agents in a query.