### PR TITLE
Handle bad readings better

### DIFF
--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -297,7 +297,7 @@ class DatabaseManager(object):
             reader = Column(String(20), nullable=False)
             reader_version = Column(String(20), nullable=False)
             format = Column(String(20), nullable=False)  # xml, json, etc.
-            bytes = Column(Bytea, nullable=False)
+            bytes = Column(Bytea)
             create_date = Column(DateTime, default=func.now())
             last_updated = Column(DateTime, onupdate=func.now())
             __table_args__ = (

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -86,6 +86,9 @@ class DatabaseReadingData(ReadingData):
 
     def zip_content(self):
         """Compress the content, returning bytes."""
+        if self.content is None:
+            return None
+
         if self.format == formats.JSON:
             ret = zip_string(json.dumps(self.content))
         elif self.format == formats.TEXT or self.format == formats.EKB:

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -437,7 +437,8 @@ class DatabaseReader(object):
         self._db.copy('raw_statements', stmt_tuples.values(),
                       DatabaseStatementData.get_cols(), lazy=True,
                       push_conflict=True,
-                      constraint='reading_raw_statement_uniqueness')
+                      constraint='reading_raw_statement_uniqueness',
+                      commit=False)
 
         # Dump the duplicates into a separate to all for debugging.
         self._db.copy('rejected_statements', [tpl for dlist in dups.values()


### PR DESCRIPTION
Rather than ignoring readings that fail, add entries in the database with null values to mark their place. This will prevent bad content from being re-read unnecessarily. This PR also makes it so that Raw and Rejected statements are committed at the same time, to prevent inconsistent states.