### PR TITLE
Fix various bugs related to reading pipeline

### DIFF
--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -393,6 +393,7 @@ class DatabaseManager(object):
             statements = relationship(RawStatements)
             db_name = Column(String(40), nullable=False)
             db_id = Column(String, nullable=False)
+            ag_num = Column(Integer, nullable=False)
             role = Column(String(20), nullable=False)
             __table_args = (
                 UniqueConstraint('stmt_id', 'db_name', 'db_id', 'role',
@@ -411,6 +412,7 @@ class DatabaseManager(object):
             position = Column(String(10))
             residue = Column(String(5))
             modified = Column(Boolean)
+            ag_num = Column(Integer, nullable=False)
         self.RawMods = RawMods
         self.tables[RawMods.__tablename__] = RawMods
 
@@ -423,6 +425,7 @@ class DatabaseManager(object):
             position = Column(String(10))
             residue_from = Column(String(5))
             residue_to = Column(String(5))
+            ag_num = Column(Integer, nullable=False)
         self.RawMuts = RawMuts
         self.tables[RawMuts.__tablename__] = RawMuts
 
@@ -472,6 +475,7 @@ class DatabaseManager(object):
             db_name = Column(String(40), nullable=False)
             db_id = Column(String, nullable=False)
             role = Column(String(20), nullable=False)
+            ag_num = Column(Integer, nullable=False)
             __table_args__ = (
                 UniqueConstraint('stmt_mk_hash', 'db_name', 'db_id', 'role',
                                  name='pa-agent-uniqueness'),
@@ -490,6 +494,7 @@ class DatabaseManager(object):
             position = Column(String(10))
             residue = Column(String(5))
             modified = Column(Boolean)
+            ag_num = Column(Integer, nullable=False)
         self.PAMods = PAMods
         self.tables[PAMods.__tablename__] = PAMods
 
@@ -503,6 +508,7 @@ class DatabaseManager(object):
             position = Column(String(10))
             residue_from = Column(String(5))
             residue_to = Column(String(5))
+            ag_num = Column(Integer, nullable=False)
         self.PAMuts = PAMuts
         self.tables[PAMuts.__tablename__] = PAMuts
 

--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -34,7 +34,6 @@ class ReadingManager(object):
         self.reader_classes = [get_reader_class(reader_name)
                                for reader_name in reader_names]
         self.buffer = timedelta(days=buffer_days)
-        self.reader_version = self.reader.get_version()
         self.run_datetime = None
         self.begin_datetime = None
         self.end_datetime = None

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -451,7 +451,7 @@ class DatabaseReader(object):
         # Add the agents for the accepted statements.
         logger.info("Uploading agents to the database.")
         if len(stmts):
-            insert_raw_agents(self._db, batch_id, stmts, verbose=True)
+            insert_raw_agents(self._db, batch_id, stmts, verbose=False)
         self.stops['dump_statements_db'] = datetime.now()
         return
 

--- a/indra_db/reading/submit_reading_pipeline.py
+++ b/indra_db/reading/submit_reading_pipeline.py
@@ -149,12 +149,10 @@ class DbReadingSubmitter(Submitter):
             for any reason external measures are needed, this option may be set
             to True.
         """
-        # Don't wait if there is no job list.
-        if not self.job_list:
-            return
         kwargs['result_record'] = self.run_record
         super(DbReadingSubmitter, self).watch_and_wait(*args, **kwargs)
-        self.produce_report()
+        if self.job_list:
+            self.produce_report()
 
     @staticmethod
     def _parse_time(time_str):


### PR DESCRIPTION
This PR also adds an agent number `ag_num` -- corresponding to the index of the agent in the deep-sorted agent list -- to the tables relating to agent metadata. This will allow the refs for a specific agent to be reconstructed just from that metadata, even if the `role` is 'OTHER'.