### PR TITLE
Improve the time-logging stats.

### DIFF
--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -351,6 +351,10 @@ class DatabaseReader(object):
         logger.info("Beginning to dump %d readings for %s to the database."
                     % (len(self.new_readings), self.reader.name))
         self.starts['dump_readings_db'] = datetime.utcnow()
+        if not self.new_readings:
+            logger.info("No new readings to load.")
+            return
+
         db = self._db
 
         # Get the id for this batch of uploads.

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -310,7 +310,7 @@ class DatabaseReader(object):
         """
         logger.info("Creating new readings from the database for %s."
                     % self.reader.name)
-        self.starts['new_readings'] = datetime.now()
+        self.starts['new_readings'] = datetime.utcnow()
         # Iterate
         logger.debug("Beginning to iterate.")
         self.reader.read(self.iter_over_content(), **kwargs)
@@ -318,7 +318,7 @@ class DatabaseReader(object):
             self.new_readings.extend(self.reader.results)
         logger.debug("Finished iteration.")
 
-        self.stops['new_readings'] = datetime.now()
+        self.stops['new_readings'] = datetime.utcnow()
         logger.info("Made %d new readings." % len(self.new_readings))
         return
 
@@ -326,7 +326,7 @@ class DatabaseReader(object):
         """Get readings from the database."""
         logger.info("Loading pre-existing readings from the database for %s."
                     % self.reader.name)
-        self.starts['old_readings'] = datetime.now()
+        self.starts['old_readings'] = datetime.utcnow()
         db = self._db
         if self.tcids:
             logger.info("Looking for content matching reader %s, version %s."
@@ -343,14 +343,14 @@ class DatabaseReader(object):
                     )
         logger.info("Found %d pre-existing readings."
                     % len(self.extant_readings))
-        self.stops['old_readings'] = datetime.now()
+        self.stops['old_readings'] = datetime.utcnow()
         return
 
     def dump_readings_to_db(self):
         """Put the reading output on the database."""
         logger.info("Beginning to dump %d readings for %s to the database."
                     % (len(self.new_readings), self.reader.name))
-        self.starts['dump_readings_db'] = datetime.now()
+        self.starts['dump_readings_db'] = datetime.utcnow()
         db = self._db
 
         # Get the id for this batch of uploads.
@@ -379,21 +379,21 @@ class DatabaseReader(object):
                               db.Reading.batch_id == batch_id)
         for tpl in rdata:
             rd_dict[tuple(tpl[1:])].reading_id = tpl[0]
-        self.stops['dump_readings_db'] = datetime.now()
+        self.stops['dump_readings_db'] = datetime.utcnow()
         return
 
     def dump_readings_to_pickle(self, pickle_file):
         """Dump the reading results into a pickle file."""
         logger.info("Beginning to dump %d readings for %s to %s."
                     % (len(self.new_readings), self.reader.name, pickle_file))
-        self.starts['dump_readings_pkl'] = datetime.now()
+        self.starts['dump_readings_pkl'] = datetime.utcnow()
         with open(pickle_file, 'wb') as f:
             rdata = [output.make_tuple(None)
                      for output in self.new_readings + self.extant_readings]
             pickle.dump(rdata, f)
             logger.info("Reading outputs pickled in: %s" % pickle_file)
 
-        self.stops['dump_readings_pkl'] = datetime.now()
+        self.stops['dump_readings_pkl'] = datetime.utcnow()
         return
 
     def get_readings(self):
@@ -414,7 +414,7 @@ class DatabaseReader(object):
 
     def dump_statements_to_db(self):
         """Upload the statements to the database."""
-        self.starts['dump_statements_db'] = datetime.now()
+        self.starts['dump_statements_db'] = datetime.utcnow()
         logger.info("Uploading %d statements to the database." %
                     len(self.statement_outputs))
         batch_id = self._db.make_copy_batch_id()
@@ -452,28 +452,28 @@ class DatabaseReader(object):
         logger.info("Uploading agents to the database.")
         if len(stmts):
             insert_raw_agents(self._db, batch_id, stmts, verbose=False)
-        self.stops['dump_statements_db'] = datetime.now()
+        self.stops['dump_statements_db'] = datetime.utcnow()
         return
 
     def dump_statements_to_pickle(self, pickle_file):
         """Dump the statements into a pickle file."""
-        self.starts['dump_statements_pkl'] = datetime.now()
+        self.starts['dump_statements_pkl'] = datetime.utcnow()
         with open(pickle_file, 'wb') as f:
             pickle.dump([sd.statement for sd in self.statement_outputs], f)
         print("Statements pickled in %s." % pickle_file)
-        self.stops['dump_readings_pkl'] = datetime.now()
+        self.stops['dump_readings_pkl'] = datetime.utcnow()
         return
 
     def get_statements(self):
         """Convert the reader output into a list of StatementData instances."""
-        self.starts['make_statements'] = datetime.now()
+        self.starts['make_statements'] = datetime.utcnow()
         if self.stmt_mode == 'all':
             all_outputs = self.new_readings + self.extant_readings
             self.statement_outputs = make_statements(all_outputs, self.n_proc)
         elif self.stmt_mode == 'unread':
             self.statement_outputs = make_statements(self.new_readings,
                                                      self.n_proc)
-        self.stops['make_statements'] = datetime.now()
+        self.stops['make_statements'] = datetime.utcnow()
         return
 
 

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -353,6 +353,7 @@ class DatabaseReader(object):
         self.starts['dump_readings_db'] = datetime.utcnow()
         if not self.new_readings:
             logger.info("No new readings to load.")
+            self.stops['dump_readings_db'] = datetime.utcnow()
             return
 
         db = self._db

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -373,12 +373,13 @@ class DatabaseReader(object):
                     DatabaseReadingData.get_cols(), lazy=is_all,
                     push_conflict=is_all)
 
-        # Update the reading_data objects with their reading_ids.
-        rdata = db.select_all([db.Reading.id, db.Reading.text_content_id,
-                               db.Reading.reader, db.Reading.reader_version],
-                              db.Reading.batch_id == batch_id)
-        for tpl in rdata:
-            rd_dict[tuple(tpl[1:])].reading_id = tpl[0]
+            # Update the reading_data objects with their reading_ids.
+            rdata = db.select_all([db.Reading.id, db.Reading.text_content_id,
+                                   db.Reading.reader, db.Reading.reader_version],
+                                  db.Reading.batch_id == batch_id)
+            for tpl in rdata:
+                rd_dict[tuple(tpl[1:])].reading_id = tpl[0]
+
         self.stops['dump_readings_db'] = datetime.utcnow()
         return
 

--- a/indra_db/reading/read_db_aws.py
+++ b/indra_db/reading/read_db_aws.py
@@ -114,10 +114,6 @@ if __name__ == '__main__':
         ("The combination of reading mode %s and statement mode %s is not "
          "allowed." % (args.reading_mode, args.stmt_mode))
 
-    # Init some timing dicts
-    starts = {}
-    ends = {}
-
     # Get a handle for the database
     if args.test:
         from indra_db import util as dbu
@@ -129,11 +125,9 @@ if __name__ == '__main__':
                      % (args.basename, args.job_name))
 
     # Read everything ========================================
-    starts['reading'] = datetime.now()
     workers = run_reading(readers, tcids, verbose=True, db=db,
                           reading_mode=args.read_mode,
                           stmt_mode=args.stmt_mode)
-    ends['reading'] = datetime.now()
 
     # Preserve the sparser logs
     contents = os.listdir('.')
@@ -150,7 +144,4 @@ if __name__ == '__main__':
 
     # Create a summary report.
     rep = DbAwsStatReporter(args.job_name, s3_log_prefix, client, bucket_name)
-    reading_outputs = [rd for worker in workers
-                       for rd in worker.extant_readings + worker.new_readings]
-    stmt_outputs = [s for worker in workers for s in worker.statement_outputs]
     rep.report_statistics(workers)

--- a/indra_db/reading/report_db_aws.py
+++ b/indra_db/reading/report_db_aws.py
@@ -264,7 +264,7 @@ class DbAwsStatReporter(Reporter):
             for key, val in worker.stops.items():
                 ends[worker.reader.name + '_' + key] = val
 
-        starts['stats'] = datetime.now()
+        starts['stats'] = datetime.utcnow()
         for k, end in ends.items():
             self._make_job_line(k + ' start', str(starts[k]))
             self._make_job_line(k + ' end', str(end))
@@ -299,7 +299,7 @@ class DbAwsStatReporter(Reporter):
         self._populate_hist_data(readings_with_stmts, readings_with_no_stmts)
         self._make_histograms()
         self._make_text_summary()
-        ends['stats'] = datetime.now()
+        ends['stats'] = datetime.utcnow()
 
         fname = self.make_report()
         with open(fname, 'rb') as f:

--- a/indra_db/reading/submit_reading_pipeline.py
+++ b/indra_db/reading/submit_reading_pipeline.py
@@ -269,13 +269,8 @@ class DbReadingSubmitter(Submitter):
         stages = [stg for _, stg in sorted(stages)]
 
         # Use this for getting the minimum and maximum.
-        all_times = [dt for job in job_segs.values() for stage in job.values()
-                     for metric, dt in stage.items() if metric != 'duration']
-        all_start = min(all_times)
-        all_end = max(all_times)
-
         def get_time_tuple(stage_data):
-            start_seconds = (stage_data['start'] - all_start).total_seconds()
+            start_seconds = (stage_data['start'] - self.start_time).total_seconds()
             return start_seconds, stage_data['duration'].total_seconds()
 
         # Make the broken barh plots.
@@ -317,9 +312,7 @@ class DbReadingSubmitter(Submitter):
             spine.set_visible(False)
         ax0.set_xlim(0, total_time)
         ax0.set_ylabel(self.basename + '_ ...')
-        print(ytick_pairs)
         yticks, ylabels = zip(*ytick_pairs)
-        print(yticks)
         if not self.ids_per_job:
             print([yticks[i+1] - yticks[i]
                    for i in range(len(yticks) - 1)])
@@ -329,8 +322,6 @@ class DbReadingSubmitter(Submitter):
             spacing = max([1, spacing])
         else:
             spacing = self.ids_per_job
-        print(spacing)
-        print(yticks[0], yticks[-1])
         ytick_range = list(arange(yticks[0], yticks[-1] + spacing, spacing))
         ylabel_filled = []
         for ytick in ytick_range:

--- a/indra_db/reading/submit_reading_pipeline.py
+++ b/indra_db/reading/submit_reading_pipeline.py
@@ -271,7 +271,7 @@ class DbReadingSubmitter(Submitter):
         stages = [stg for _, stg in sorted(stages)]
 
         # Add data from local records, if available.
-        if self.run_record is not None:
+        if self.run_record:
             for final_status in ['failed', 'succeeded']:
                 for job in self.run_record[final_status]:
                     if job['jobName'] in job_segs.keys():
@@ -337,7 +337,7 @@ class DbReadingSubmitter(Submitter):
             job_d = job_segs[job_name]
 
             # Plot the overall job run info, if known.
-            if self.run_record is not None:
+            if self.run_record:
                 ts = [(job_d[k] - self.start_time).total_seconds()
                       for k in ['job_created', 'job_started', 'job_stopped']]
                 xs = [(ts[0], ts[1] - ts[0]), (ts[1], ts[2] - ts[1])]

--- a/indra_db/reading/submit_reading_pipeline.py
+++ b/indra_db/reading/submit_reading_pipeline.py
@@ -310,7 +310,7 @@ class DbReadingSubmitter(Submitter):
             start_seconds = (stage_data['start'] - self.start_time).total_seconds()
             dur = stage_data['duration'].total_seconds()
             if start_seconds > t_gap:
-                start_seconds -= t_gap/2
+                start_seconds += t_gap/2
 
             if dur > t_gap:
                 dur -= t_gap
@@ -320,7 +320,9 @@ class DbReadingSubmitter(Submitter):
             return start_seconds, dur
 
         def make_y(start, end, scale):
-            return start, (end - start)*scale
+            h = end - start
+            start += (1 - scale)*h/2
+            return start, h*scale
 
         label_size = 5
         # Make the broken barh plots from internal info -----------------------
@@ -367,7 +369,7 @@ class DbReadingSubmitter(Submitter):
 
             # Plot the more detailed info
             xs = [get_time_tuple(job_d.get(stg)) for stg in stages]
-            ys = make_y(s_ix, e_ix, 0.6)
+            ys = make_y(s_ix, e_ix, 0.4)
             logger.debug("Making plot for: %s" % str((job_name, xs, ys)))
             facecolors = [get_stage_choices(stg)[1] for stg in stages]
             ax0.broken_barh(xs, ys, facecolors=facecolors)

--- a/indra_db/reading/submit_reading_pipeline.py
+++ b/indra_db/reading/submit_reading_pipeline.py
@@ -403,19 +403,27 @@ class DbReadingSubmitter(Submitter):
 
         ytick_range = list(arange(yticks[0], yticks[-1] + spacing, spacing))
         ylabel_filled = []
-        for ytick in ytick_range:
+        colored_labels = {}
+        for i, ytick in enumerate(ytick_range):
             if ytick in yticks:
                 ylabel = ylabels[yticks.index(ytick)]
                 job_d = job_segs[names[yticks.index(ytick)]]
                 if job_d.get('terminated'):
-                    ylabel = '*' + ylabel
+                    ylabel = 'T ' + ylabel
+                    colored_labels[i] = 'red'
+                elif job_d.get('final') == 'failed':
+                    ylabel = 'F ' + ylabel
+                    colored_labels[i] = 'orange'
                 ylabel_filled.append(ylabel)
             else:
-                ylabel_filled.append('MISSING')
+                ylabel_filled.append('FAILED')
         ax0.set_ylim(0, max(ytick_range) + spacing)
         ax0.set_yticks(ytick_range)
         ax0.set_yticklabels(ylabel_filled)
         ax0.tick_params(labelsize=label_size)
+        for i, ytick in enumerate(ax0.get_yticklabels()):
+            if i in colored_labels.keys():
+                ytick.set_color(colored_labels[i])
 
         # Plot the lower axis -------------------------------------------------
         ax1 = plt.subplot(gs[1], sharex=ax0)


### PR DESCRIPTION
Uses data gathered by the submitter object to plot the job submit times and run times as reported by Batch. Among other benefits, this allows some tracking of the failed jobs. This PR also standardizes datetimes to UTC.