### PR TITLE
Convert reading ids to be hashes

### DIFF
--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -361,7 +361,7 @@ class DatabaseManager(object):
             source_hash = Column(BigInteger, nullable=False)
             db_info_id = Column(Integer, ForeignKey('db_info.id'))
             db_info = relationship(DBInfo)
-            reading_id = Column(Integer, ForeignKey('reading.id'))
+            reading_id = Column(BigInteger, ForeignKey('reading.id'))
             reading = relationship(Reading)
             type = Column(String(100), nullable=False)
             indra_version = Column(String(100), nullable=False)

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -1,7 +1,7 @@
 from sqlalchemy.exc import NoSuchTableError
 
 __all__ = ['sqltypes', 'texttypes', 'formats', 'DatabaseManager',
-           'IndraDbException', 'sql_expressions']
+           'IndraDbException', 'sql_expressions', 'readers', 'reader_versions']
 
 import re
 import random
@@ -118,6 +118,18 @@ class formats(_map_class):
     TEXT = 'text'
     JSON = 'json'
     EKB = 'ekb'
+
+
+readers = {'REACH': 1, 'SPARSER': 2, 'TRIPS': 3}
+
+
+# Specify versions of readers, and preference. Later in the list is better.
+reader_versions = {
+    'sparser': ['sept14-linux\n', 'sept14-linux', 'June2018-linux',
+                'October2018-linux'],
+    'reach': ['61059a-biores-e9ee36', '1.3.3-61059a-biores-'],
+    'trips': ['STATIC']
+}
 
 
 class IndraTableError(IndraDbException):

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -309,7 +309,7 @@ class DatabaseManager(object):
         class Reading(self.Base, Displayable):
             __tablename__ = 'reading'
             _skip_disp = ['bytes']
-            id = Column(Integer, primary_key=True)
+            id = Column(BigInteger, primary_key=True, default=None)
             text_content_id = Column(Integer,
                                      ForeignKey('text_content.id'),
                                      nullable=False)

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -387,7 +387,7 @@ class DatabaseManager(object):
             source_hash = Column(BigInteger, nullable=False)
             db_info_id = Column(Integer, ForeignKey('db_info.id'))
             db_info = relationship(DBInfo)
-            reading_id = Column(Integer, ForeignKey('reading.id'))
+            reading_id = Column(BigInteger, ForeignKey('reading.id'))
             reading = relationship(Reading)
             type = Column(String(100), nullable=False)
             indra_version = Column(String(100), nullable=False)
@@ -627,7 +627,7 @@ class DatabaseManager(object):
             _skip_disp = ['raw_json', 'pa_json']
             id = Column(Integer, primary_key=True)
             raw_json = Column(BYTEA)
-            reading_id = Column(Integer, ForeignKey('reading_ref_link.rid'))
+            reading_id = Column(BigInteger, ForeignKey('reading_ref_link.rid'))
             reading_ref = relationship(ReadingRefLink)
             db_info_id = Column(Integer)
             mk_hash = Column(BigInteger, ForeignKey('evidence_counts.mk_hash'))

--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -116,7 +116,7 @@ class BulkReadingManager(ReadingManager):
             db.TextContent.insert_date > self.begin_datetime
             )
         tcids = {tcid for tcid, in tcid_q.all()}
-        self._run_reading(db, tcids)
+        self._run_reading(db, tcids, reader_class)
         return True
 
 

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -111,6 +111,7 @@ class DatabaseReadingData(ReadingData):
             self.reading_id += (reader_versions[self.reader.lower()]
                                 .index(self.reader_version[:20])*10e10)
             self.reading_id += self.tcid
+            self.reading_id = int(self.reading_id)
         return self.reading_id
 
     def matches(self, r_entry):

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -373,14 +373,6 @@ class DatabaseReader(object):
         # Get the id for this batch of uploads.
         batch_id = db.make_copy_batch_id()
 
-        # DEBUG =========
-        pkl = pickle.dumps(self.new_readings)
-        s3 = boto3.client('s3')
-        s3.put_object(Bucket='bigmech',
-                      Key='indra-db/new_readings_%s.pkl' % self.tcids[0],
-                      Body=pkl)
-        # ================
-
         # Make a list of data to copy, ensuring there are no conflicts.
         upload_list = []
         rd_dict = {}

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from math import ceil
 from multiprocessing.pool import Pool
 
+import boto3
+
 from indra.statements import make_hash
 
 from indra.tools.reading.util.script_tools import get_parser
@@ -369,6 +371,14 @@ class DatabaseReader(object):
 
         # Get the id for this batch of uploads.
         batch_id = db.make_copy_batch_id()
+
+        # DEBUG =========
+        pkl = pickle.dumps(self.new_readings)
+        s3 = boto3.client('s3')
+        s3.put_object(Bucket='bigmech',
+                      Key='indra-db/new_readings_%s.pkl' % self.tcids[0],
+                      Body=pkl)
+        # ================
 
         # Make a list of data to copy, ensuring there are no conflicts.
         upload_list = []

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -387,13 +387,6 @@ class DatabaseReader(object):
                     DatabaseReadingData.get_cols(), lazy=is_all,
                     push_conflict=is_all)
 
-            # Update the reading_data objects with their reading_ids.
-            rdata = db.select_all([db.Reading.id, db.Reading.text_content_id,
-                                   db.Reading.reader, db.Reading.reader_version],
-                                  db.Reading.batch_id == batch_id)
-            for tpl in rdata:
-                rd_dict[tuple(tpl[1:])].reading_id = tpl[0]
-
         self.stops['dump_readings_db'] = datetime.utcnow()
         return
 

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -109,7 +109,7 @@ class DatabaseReadingData(ReadingData):
         if self.reading_id is None:
             self.reading_id = readers[self.reader.upper()]*10e12
             self.reading_id += (reader_versions[self.reader.lower()]
-                                .index(self.reader_version)*10e10)
+                                .index(self.reader_version[:20])*10e10)
             self.reading_id += self.tcid
         return self.reading_id
 

--- a/indra_db/util/distill_statements.py
+++ b/indra_db/util/distill_statements.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from indra.util import clockit
 from indra.statements import Statement
 from indra.util.nested_dict import NestedDict
+from indra_db.managers.database_manager import reader_versions
 
 from .helpers import _set_evidence_text_ref
 
@@ -123,14 +124,6 @@ def get_reading_stmt_dict(db, clauses=None, get_full_stmts=True):
     print("number of unique statements: %d" % num_unique_evidence)
     return stmt_nd
 
-
-# Specify versions of readers, and preference. Later in the list is better.
-reader_versions = {
-    'sparser': ['sept14-linux\n', 'sept14-linux', 'June2018-linux',
-                'October2018-linux'],
-    'reach': ['61059a-biores-e9ee36', '1.3.3-61059a-biores-'],
-    'trips': ['STATIC']
-}
 
 # Specify sources of fulltext content, and order priorities.
 text_content_sources = [('pubmed', 'title'), ('pubmed', 'abstract'),


### PR DESCRIPTION
Construct hashes from reading metadata rather than having ids assigned by the database. This makes ids bigints (as opposed to ints), but prevents needing to lookup the newly assigned reading ids from the database before inserting raw statements, which have a foreign key into the reading ids.

This has been tested on batch and tremendously speeds up the bulk batch reading.