### PR TITLE
Add more Knowledge Bases

### DIFF
--- a/indra_db/managers/knowledgebase_manager.py
+++ b/indra_db/managers/knowledgebase_manager.py
@@ -302,6 +302,20 @@ class RlimspManager(KnowledgebaseManager):
         return stmts
 
 
+class TrrustManager(KnowledgebaseManager):
+    name = 'trrust'
+    source = 'trrust'
+
+    def _get_statements(self):
+        from indra.sources import trrust
+        tp = trrust.process_from_web()
+        unique_stmts, dups = \
+            extract_duplicates(_expanded(tp.statements),
+                               key_func=KeyFunc.mk_and_one_ev_src)
+        print(len(dups))
+        return unique_stmts
+
+
 def _expanded(stmts):
     for stmt in stmts:
         # Only one evidence is allowed for each statement.

--- a/indra_db/managers/knowledgebase_manager.py
+++ b/indra_db/managers/knowledgebase_manager.py
@@ -329,3 +329,20 @@ def _expanded(stmts):
                 yield new_stmt
         else:
             yield stmt
+
+
+if __name__ == '__main__':
+    import sys
+    from indra_db.util import get_db
+    mode = sys.argv[1]
+    db = get_db('primary')
+    for Manager in KnowledgebaseManager.__subclasses__():
+        kbm = Manager()
+        print(kbm.name, '...')
+        if mode == 'upload':
+            kbm.upload(db)
+        elif mode == 'update':
+            kbm.update(db)
+        else:
+            print("Invalid mode: %s" % mode)
+            sys.exit(1)

--- a/indra_db/managers/knowledgebase_manager.py
+++ b/indra_db/managers/knowledgebase_manager.py
@@ -178,8 +178,7 @@ class PathwayCommonsManager(KnowledgebaseManager):
     def _get_statements(self):
         s3 = boto3.client('s3')
 
-        resp = s3.get_object(Bucket='bioexp-paper',
-                             Key='bioexp_biopax_pc10.pkl')
+        resp = s3.get_object(Bucket='indra-db', Key='biopax_pc11.pkl')
         stmts = pickle.loads(resp['Body'].read())
 
         filtered_stmts = [s for s in _expanded(stmts) if self._can_include(s)]

--- a/indra_db/managers/knowledgebase_manager.py
+++ b/indra_db/managers/knowledgebase_manager.py
@@ -1,11 +1,14 @@
-import os
-import tempfile
-import zlib
-from collections import defaultdict
+__all__ = ['TasManager', 'CBNManager', 'HPRDManager', 'SignorManager',
+           'BiogridManager', 'BelLcManager', 'PathwayCommonsManager',
+           'RlimspManager', 'TrrustManager', 'PhosphositeManager']
 
+import os
+import zlib
 import boto3
 import pickle
 import logging
+import tempfile
+from collections import defaultdict
 
 from indra_db.util import insert_db_stmts
 from indra_db.util.distill_statements import extract_duplicates, KeyFunc
@@ -54,7 +57,7 @@ class KnowledgebaseManager(object):
             dbid = dbinfo.id
             if dbinfo.source_api != self.source:
                 dbinfo.source_api = self.source
-                db.commit("Could no update source_api for %s."
+                db.commit("Could not update source_api for %s."
                           % dbinfo.db_name)
         return dbid
 
@@ -179,7 +182,7 @@ class PathwayCommonsManager(KnowledgebaseManager):
     def _get_statements(self):
         s3 = boto3.client('s3')
 
-        resp = s3.get_object(Bucket='indra-db', Key='biopax_pc11.pkl')
+        resp = s3.get_object(Bucket='bigmech', Key='indra-db/biopax_pc11.pkl')
         stmts = pickle.loads(resp['Body'].read())
 
         filtered_stmts = [s for s in _expanded(stmts) if self._can_include(s)]
@@ -265,7 +268,7 @@ class PhosphositeManager(KnowledgebaseManager):
                              Key='indra-db/Kinase_substrates.owl.gz')
         owl_gz = resp['Body'].read()
         owl_bytes = zlib.decompress(owl_gz, zlib.MAX_WBITS + 32)
-        bp = biopax.process_owl_str(owl_bytes.decode('utf-8'))
+        bp = biopax.process_owl_str(owl_bytes)
         stmts, dups = extract_duplicates(bp.statements,
                                          key_func=KeyFunc.mk_and_one_ev_src)
         print('\n'.join(str(dup) for dup in dups))


### PR DESCRIPTION
Add knowledge bases for PSP, Trrust, and RLIMS-P. This PR also introduces the `source` attribute of `db_info` entries, which indicates which source API corresponds to each knowledge base (e.g. biopax), as is used in belief calculations (this will allow belief to be calculated again strictly from metadata).