### PR TITLE
Content script update

### DIFF
--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -9,7 +9,7 @@ class _DatabaseTestSetup(_PrePaDatabaseTestSetup):
 
 def _make_test_db_input():
     test_database = {}
-    raw_statement_cols, raw_statement_tuples = raw_statement_dict = \
+    raw_statement_cols, raw_statement_tuples, raw_statement_dict = \
         _make_raw_statements_input()
     test_database['raw_statements'] = {'cols': raw_statement_cols,
                                        'tuples': raw_statement_tuples,
@@ -85,7 +85,7 @@ def _make_raw_agents_input():
                         (7, 1, 'HGNC', '20387', 'OBJECT')]
 
     raw_agent_dict = {x[0]: x for x in raw_agent_tuples}
-    return raw_agent_cols, raw_agent_dict
+    return raw_agent_cols, raw_agent_tuples, raw_agent_dict
 
 
 def _make_readings_input():

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -200,14 +200,14 @@ def _make_raw_agents_input():
                         (1, 0, 'HGNC', 'ESR1', 'SUBJECT', 0),
                         (2, 1, 'TEXT', 'NPs', 'SUBJECT', 0),
                         (3, 1, 'HGNC', '33940', 'SUBJECT', 0),
-                        (4, 0, 'TEXT', 'damage', 'OBJECT', 0),
-                        (5, 0, 'HGNC', '24934', 'OBJECT', 0),
-                        (6, 1, 'TEXT', 'impact', 'OBJECT', 0),
-                        (7, 1, 'HGNC', '20387', 'OBJECT', 0),
+                        (4, 0, 'TEXT', 'damage', 'OBJECT', 1),
+                        (5, 0, 'HGNC', '24934', 'OBJECT', 1),
+                        (6, 1, 'TEXT', 'impact', 'OBJECT', 1),
+                        (7, 1, 'HGNC', '20387', 'OBJECT', 1),
                         (8, 2, 'TEXT', 'DL', 'SUBJECT', 0),
                         (9, 2, 'MESH', 'D000077321', 'SUBJECT', 0),
-                        (10, 2, 'TEXT', 'health', 'OBJECT', 0),
-                        (11, 2, 'MESH', 'D006262', 'OBJECT', 0)]
+                        (10, 2, 'TEXT', 'health', 'OBJECT', 1),
+                        (11, 2, 'MESH', 'D006262', 'OBJECT', 1)]
     raw_agent_dict = {x[0]: x for x in raw_agent_tuples}
     return raw_agent_cols, raw_agent_tuples, raw_agent_dict
 

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -62,6 +62,23 @@ def test_get_text_content_from_stmt_ids():
     assert text_dict[1] == fulltext1
 
 
+def test_get_text_content_from_text_refs():
+    fulltext0 = ('We investigate properties of the estrogen receptor (ER).'
+                 ' Our investigation made no new findings about ER, leading to'
+                 ' damage in our groups abilty to secure funding.')
+    fulltext1 = ('We describe an experiment about nanoparticles (NPs).'
+                 ' The experiment was a complete failure. Our inability to'
+                 ' produce sufficient quantities of NPs has made a troubling'
+                 ' impact on the future of our lab. The following figure'
+                 ' contains a schematic diagram of the apparatus of our'
+                 ' experiment.')
+    db = _get_prepped_db()
+    text = get_text_content_from_text_refs({'PMID': '000000'}, db=db)
+    assert text == fulltext0
+    text = get_text_content_from_text_refs({'PMID': '777777'}, db=db)
+    assert text == fulltext1
+
+
 def _get_prepped_db():
     dts = _DatabaseTestSetup()
     dts.load_tables()

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -138,11 +138,6 @@ def _make_text_content_input():
                  ' impact on the future of our lab. The following figure'
                  ' contains a schematic diagram of the apparatus of our'
                  ' experiment.')
-
-    text_content_tuples = [(0, 0, 'pubmed', 'abstract', 'text', abstract0),
-                           (1, 0, 'pmc', 'fulltext', 'text', fulltext0),
-                           (2, 1, 'pubmed', 'abstract', 'text', abstract1),
-                           (3, 1, 'pmc', 'fulltext', 'text', fulltext1)]
     abstract2 = ('We describe applications of nanoparticles (NPs) to'
                  ' grant procurement. We find that mentions of NPs in'
                  ' grant proposals has a positive correlation with the'
@@ -150,6 +145,16 @@ def _make_text_content_input():
                  ' NPs is shown to increase the health of research'
                  ' programs')
 
+    text_content_tuples = [(0, 0, 'pubmed', 'abstract', 'text',
+                            zip_string(abstract0)),
+                           (1, 0, 'pmc', 'fulltext', 'text',
+                            zip_string(fulltext0)),
+                           (2, 1, 'pubmed', 'abstract', 'text',
+                            zip_string(abstract1)),
+                           (3, 1, 'pmc', 'fulltext', 'text',
+                            zip_string(fulltext1)),
+                           (4, 2, 'pubmed', 'abstract', 'text',
+                            zip_string(abstract2))]
     text_content_dict = {x[0]: x for x in text_content_tuples}
     return text_content_cols, text_content_tuples, text_content_dict
 

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -140,7 +140,17 @@ def _make_raw_statements_input():
                              b'"evidence": [{"source_api": "rdr", "text":'
                              b'"Our inability to produce sufficient quantities'
                              b' of NPs has made a troubling impact on the'
-                             b' future of our lab."}]}', 1, 1)]
+                             b' future of our lab ."}]}', 1, 1),
+                            (2, '2', '3.14', 2, 2, None, 'IncreaseAmount',
+                             b'{"type": "IncreaseAmount", "sub":'
+                             b' {"name": "Deep Learning", "db_refs":'
+                             b'{"TEXT": "DL", "MESH": "D000077321"}},'
+                             b'"obj": {"name": "Health",'
+                             b'"db_refs":'
+                             b'{"TEXT": "health", "MESH": "D006262"}},'
+                             b'"evidence": [{"source_api": "rdr", "text":'
+                             b'"Research into DL is shown to increase'
+                             b' the health of research programs."}]}', 1, 1)]
 
     raw_statement_dict = {x[0]: x for x in raw_statement_tuples}
     return raw_statement_cols, raw_statement_tuples, raw_statement_dict
@@ -156,8 +166,8 @@ def _make_raw_agents_input():
                         (5, 0, 'HGNC', '24934', 'OBJECT', 0),
                         (6, 1, 'TEXT', 'impact', 'OBJECT', 0),
                         (7, 1, 'HGNC', '20387', 'OBJECT', 0),
-                        (8, 2, 'TEXT', 'NPs', 'SUBJECT', 0),
-                        (9, 2, 'MESH', 'D053758', 'SUBJECT', 0),
+                        (8, 2, 'TEXT', 'DL', 'SUBJECT', 0),
+                        (9, 2, 'MESH', 'D000077321', 'SUBJECT', 0),
                         (10, 2, 'TEXT', 'health', 'OBJECT', 0),
                         (11, 2, 'MESH', 'D006262', 'OBJECT', 0)]
     raw_agent_dict = {x[0]: x for x in raw_agent_tuples}
@@ -191,11 +201,11 @@ def _make_text_content_input():
                  ' impact on the future of our lab. The following figure'
                  ' contains a schematic diagram of the apparatus of our'
                  ' experiment.')
-    abstract2 = ('We describe applications of nanoparticles (NPs) to'
-                 ' grant procurement. We find that mentions of NPs in'
+    abstract2 = ('We describe applications of deep learning (DL) to'
+                 ' grant procurement. We find that mentions of DL in'
                  ' grant proposals has a positive correlation with the'
                  ' likelihood an application is accepted. Research into'
-                 ' NPs is shown to increase the health of research'
+                 ' DL is shown to increase the health of research'
                  ' programs')
 
     text_content_tuples = [(0, 0, 'pubmed', 'abstract', 'text',

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -93,25 +93,29 @@ def _make_raw_statements_input():
 
 
 def _make_raw_agents_input():
-    raw_agent_cols = ('id', 'stmt_id', 'db_name', 'db_id', 'role')
-    raw_agent_tuples = [(0, 0, 'TEXT', 'ER', 'SUBJECT'),
-                        (1, 0, 'HGNC', 'ESR1', 'SUBJECT'),
-                        (2, 1, 'TEXT', 'NPs', 'SUBJECT'),
-                        (3, 1, 'HGNC', '33940', 'SUBJECT'),
-                        (4, 0, 'TEXT', 'damage', 'OBJECT'),
-                        (5, 0, 'HGNC', '24934', 'OBJECT'),
-                        (6, 1, 'TEXT', 'impact', 'OBJECT'),
-                        (7, 1, 'HGNC', '20387', 'OBJECT')]
-
+    raw_agent_cols = ('id', 'stmt_id', 'db_name', 'db_id', 'role', 'ag_num')
+    raw_agent_tuples = [(0, 0, 'TEXT', 'ER', 'SUBJECT', 0),
+                        (1, 0, 'HGNC', 'ESR1', 'SUBJECT', 0),
+                        (2, 1, 'TEXT', 'NPs', 'SUBJECT', 0),
+                        (3, 1, 'HGNC', '33940', 'SUBJECT', 0),
+                        (4, 0, 'TEXT', 'damage', 'OBJECT', 0),
+                        (5, 0, 'HGNC', '24934', 'OBJECT', 0),
+                        (6, 1, 'TEXT', 'impact', 'OBJECT', 0),
+                        (7, 1, 'HGNC', '20387', 'OBJECT', 0),
+                        (8, 2, 'TEXT', 'NPs', 'SUBJECT', 0),
+                        (9, 2, 'MESH', 'D053758', 'SUBJECT', 0),
+                        (10, 2, 'TEXT', 'health', 'OBJECT', 0),
+                        (11, 2, 'MESH', 'D006262', 'OBJECT', 0)]
     raw_agent_dict = {x[0]: x for x in raw_agent_tuples}
     return raw_agent_cols, raw_agent_tuples, raw_agent_dict
 
 
 def _make_readings_input():
     reading_cols = ('id', 'text_content_id', 'reader', 'reader_version',
-                    'bytes', 'format')
-    reading_tuples = [(0, 1, 'RDR', '2.78', b'\x1f', 'json'),
-                      (1, 2, 'RDR', '2.78', b'\x82', 'json')]
+                    'bytes', 'format', 'batch_id')
+    reading_tuples = [(0, 1, 'RDR', '2.78', b'\x1f', 'json', 1),
+                      (1, 2, 'RDR', '2.78', b'\x82', 'json', 1),
+                      (2, 4, 'RDR', '2.78', b'\x17', 'json', 1)]
     reading_dict = {x[0]: x for x in reading_tuples}
     return reading_cols, reading_tuples, reading_dict
 
@@ -138,6 +142,13 @@ def _make_text_content_input():
                            (1, 0, 'pmc', 'fulltext', 'text', fulltext0),
                            (2, 1, 'pubmed', 'abstract', 'text', abstract1),
                            (3, 1, 'pmc', 'fulltext', 'text', fulltext1)]
+    abstract2 = ('We describe applications of nanoparticles (NPs) to'
+                 ' grant procurement. We find that mentions of NPs in'
+                 ' grant proposals has a positive correlation with the'
+                 ' likelihood an application is accepted. Research into'
+                 ' NPs is shown to increase the health of research'
+                 ' programs')
+
     text_content_dict = {x[0]: x for x in text_content_tuples}
     return text_content_cols, text_content_tuples, text_content_dict
 
@@ -145,6 +156,7 @@ def _make_text_content_input():
 def _make_text_ref_input():
     text_ref_cols = ('id', 'pmid', 'pmcid', 'doi', 'manuscript_id', 'pii')
     text_ref_tuples = [(0, '000000', 'PMC777777', None, None, None),
-                       (1, '777777', 'PMC000000', None, None, None)]
+                       (1, '777777', 'PMC000000', None, None, None),
+                       (2, '000001', None, None, None, None)]
     text_ref_dict = {x[0]: x for x in text_ref_tuples}
     return text_ref_cols, text_ref_tuples, text_ref_dict

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -1,3 +1,56 @@
+from indra.util import zip_string
+
+import indra_db.util as dbu
+from indra_db.util.content_scripts import (get_stmts_with_agent_text_like,
+                                           get_stmts_with_agent_text_in,
+                                           get_text_content_from_stmt_ids,
+                                           get_text_content_from_text_refs)
+
+
+def test_get_stmts_with_agent_text_like():
+    db = _get_prepped_db()
+    agent_stmts0 = get_stmts_with_agent_text_like('__', db=db)
+    assert len(agent_stmts0) == 1
+    assert 'ER' in agent_stmts0
+    assert agent_stmts0['ER'] == [0]
+
+    agent_stmts1 = get_stmts_with_agent_text_like('__s', filter_genes=True,
+                                                  db=db)
+    assert len(agent_stmts1) == 1
+    assert 'NPs' in agent_stmts1
+    assert agent_stmts1['NPs'] == [1]
+
+
+def test_get_stmts_with_agent_test_in():
+    db = _get_prepped_db()
+    agent_stmts = get_stmts_with_agent_text_in(['damage', 'impact'],
+                                               filter_genes=True, db=db)
+    assert set(agent_stmts.keys()) == set(['damage', 'impact'])
+    assert agent_stmts['damage'] == [0]
+    assert agent_stmts['impact'] == [1]
+
+
+def test_get_text_content_from_stmt_ids():
+    fulltext0 = ('We investigate properties of the estrogen receptor (ER).'
+                 ' Our investigation made no new findings about ER, leading to'
+                 ' damage in our groups abilty to secure funding.')
+    fulltext1 = ('We describe an experiment about nanoparticles (NPs).'
+                 ' The experiment was a complete failure. Our inability to'
+                 ' produce sufficient quantities of NPs has made a troubling'
+                 ' impact on the future of our lab. The following figure'
+                 ' contains a schematic diagram of the apparatus of our'
+                 ' experiment.')
+    db = _get_prepped_db()
+    ref_dict, text_dict = get_text_content_from_stmt_ids([0, 1], db=db)
+    assert ref_dict == {0: 0, 1: 1}
+    assert text_dict[0] == fulltext0
+    assert text_dict[1] == fulltext1
+
+
+def _get_prepped_db():
+    dts = _DatabaseTestSetup()
+    dts.load_tables()
+    return dts.test_db
 
 
 class _DatabaseTestSetup(object):

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -1,3 +1,5 @@
+from nose.plugins.attrib import attr
+
 from indra.util import zip_string
 
 import indra_db.util as dbu
@@ -7,6 +9,7 @@ from indra_db.util.content_scripts import (get_stmts_with_agent_text_like,
                                            get_text_content_from_text_refs)
 
 
+@attr('nonpublic')
 def test_get_stmts_with_agent_text_like():
     db = _get_prepped_db()
     agent_stmts0 = get_stmts_with_agent_text_like('__', filter_genes=True,
@@ -30,6 +33,7 @@ def test_get_stmts_with_agent_text_like():
     assert agent_stmts2['NPs'] == [1]
 
 
+@attr('nonpublic')
 def test_get_stmts_with_agent_text_in():
     db = _get_prepped_db()
     agent_stmts0 = get_stmts_with_agent_text_in(['damage', 'impact', 'health'],
@@ -45,6 +49,7 @@ def test_get_stmts_with_agent_text_in():
     assert agent_stmts1['health'] == [2]
 
 
+@attr('nonpublic')
 def test_get_text_content_from_stmt_ids():
     fulltext0 = ('We investigate properties of the estrogen receptor (ER).'
                  ' Our investigation made no new findings about ER, leading to'
@@ -62,6 +67,7 @@ def test_get_text_content_from_stmt_ids():
     assert text_dict[1] == fulltext1
 
 
+@attr('nonpublic')
 def test_get_text_content_from_text_refs():
     fulltext0 = ('We investigate properties of the estrogen receptor (ER).'
                  ' Our investigation made no new findings about ER, leading to'

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -55,8 +55,8 @@ def _make_raw_statements_input():
                              b'{"TEXT": "damage", "HGNC": "24934"}},'
                              b'"evidence": [{"source_api": "rdr", "text":'
                              b'"Our investigation made no new findings about'
-                             b'ER, leading to damage in our groups ability to'
-                             b'secure funding."}]}'),
+                             b' ER, leading to damage in our groups ability to'
+                             b' secure funding."}]}'),
                             (1, '1', '3.14', 1, 1, None, 'IncreaseAmount',
                              b'{"type": "IncreaseAmount", "sub":'
                              b' {"name": "NPS", "db_refs":'
@@ -67,7 +67,7 @@ def _make_raw_statements_input():
                              b'"evidence": [{"source_api": "rdr", "text":'
                              b'"Our inability to produce sufficient quantities'
                              b' of NPs has made a troubling impact on the'
-                             b'future of our lab."}]}')]
+                             b' future of our lab."}]}')]
 
     raw_statement_dict = {x[0]: x for x in raw_statement_tuples}
     return raw_statement_cols, raw_statement_tuples, raw_statement_dict
@@ -110,7 +110,7 @@ def _make_text_content_input():
                  ' troubling impact on the future of our lab.')
     fulltext1 = ('We describe an experiment about nanoparticles (NPs).'
                  ' The experiment was a complete failure. Our inability to'
-                 'produce sufficient quantities of NPs has made a troubling'
+                 ' produce sufficient quantities of NPs has made a troubling'
                  ' impact on the future of our lab. The following figure'
                  ' contains a schematic diagram of the apparatus of our'
                  ' experiment.')

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -86,7 +86,7 @@ def _make_raw_statements_input():
                              b'"evidence": [{"source_api": "rdr", "text":'
                              b'"Our inability to produce sufficient quantities'
                              b' of NPs has made a troubling impact on the'
-                             b' future of our lab."}]}')]
+                             b' future of our lab."}]}', 1, 1)]
 
     raw_statement_dict = {x[0]: x for x in raw_statement_tuples}
     return raw_statement_cols, raw_statement_tuples, raw_statement_dict

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -75,7 +75,7 @@ def _make_raw_statements_input():
                              b'"evidence": [{"source_api": "rdr", "text":'
                              b'"Our investigation made no new findings about'
                              b' ER, leading to damage in our groups ability to'
-                             b' secure funding."}]}'),
+                             b' secure funding."}]}', 1, 0),
                             (1, '1', '3.14', 1, 1, None, 'IncreaseAmount',
                              b'{"type": "IncreaseAmount", "sub":'
                              b' {"name": "NPS", "db_refs":'

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -32,11 +32,17 @@ def test_get_stmts_with_agent_text_like():
 
 def test_get_stmts_with_agent_text_in():
     db = _get_prepped_db()
-    agent_stmts = get_stmts_with_agent_text_in(['damage', 'impact'],
-                                               filter_genes=True, db=db)
-    assert set(agent_stmts.keys()) == set(['damage', 'impact'])
-    assert agent_stmts['damage'] == [0]
-    assert agent_stmts['impact'] == [1]
+    agent_stmts0 = get_stmts_with_agent_text_in(['damage', 'impact', 'health'],
+                                                filter_genes=True, db=db)
+    assert set(agent_stmts0.keys()) == set(['damage', 'impact'])
+    assert agent_stmts0['damage'] == [0]
+    assert agent_stmts0['impact'] == [1]
+    agent_stmts1 = get_stmts_with_agent_text_in(['damage', 'impact', 'health'],
+                                                filter_genes=False, db=db)
+    assert set(agent_stmts1.keys()) == set(['damage', 'impact', 'health'])
+    assert agent_stmts1['damage'] == [0]
+    assert agent_stmts1['impact'] == [1]
+    assert agent_stmts1['health'] == [2]
 
 
 def test_get_text_content_from_stmt_ids():

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -1,8 +1,29 @@
 
 
+class _DatabaseTestSetup(object):
     """Sets up the test database"""
     def __init__(self):
-        raise NotImplementedError
+        self.test_db = dbu.get_test_db()
+        self.test_db._clear(force=True)
+        self.test_data = _make_test_db_input()
+        self.test_db._init_auth()
+        _, api_key = self.test_db._add_auth('tester')
+        self.tester_key = api_key
+
+    def load_tables(self):
+        """Load in all the background provenance metadata (e.g. text_ref).
+
+        This must be done before you load any statements.
+        """
+        test_data = self.test_data
+        tables = ['text_ref', 'text_content', 'reading', 'db_info',
+                  'raw_statements', 'raw_agents']
+        db_inputs = {table: set(test_data[table]['tuples'])
+                     for table in tables}
+        for table in tables:
+            self.test_db.copy(table, db_inputs[table],
+                              test_data[table]['cols'])
+        return
 
 
 def _make_test_db_input():

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -9,12 +9,19 @@ from indra_db.util.content_scripts import (get_stmts_with_agent_text_like,
 
 def test_get_stmts_with_agent_text_like():
     db = _get_prepped_db()
-    agent_stmts0 = get_stmts_with_agent_text_like('__', db=db)
+    agent_stmts0 = get_stmts_with_agent_text_like('__', filter_genes=True,
+                                                  db=db)
     assert len(agent_stmts0) == 1
     assert 'ER' in agent_stmts0
     assert agent_stmts0['ER'] == [0]
 
-    agent_stmts1 = get_stmts_with_agent_text_like('__s', filter_genes=True,
+    agent_stmts1 = get_stmts_with_agent_text_like('__', filter_genes=False,
+                                                  db=db)
+    assert len(agent_stmts1) == 2
+    assert 'ER' in agent_stmts1
+    assert 'DL' in agent_stmts1
+    assert agent_stmts1['ER'] == [0]
+    assert agent_stmts1['DL'] == [2]
                                                   db=db)
     assert len(agent_stmts1) == 1
     assert 'NPs' in agent_stmts1

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -1,0 +1,131 @@
+from .test_client import _PrePaDatabaseTestSetup
+
+
+class _DatabaseTestSetup(_PrePaDatabaseTestSetup):
+    """Sets up the test database"""
+    def __init__(self):
+        raise NotImplementedError
+
+
+def _make_test_db_input():
+    test_database = {}
+    raw_statement_cols, raw_statement_tuples = raw_statement_dict = \
+        _make_raw_statements_input()
+    test_database['raw_statements'] = {'cols': raw_statement_cols,
+                                       'tuples': raw_statement_tuples,
+                                       'dict': raw_statement_dict}
+
+    raw_agent_cols, raw_agent_tuples, raw_agent_dict = \
+        _make_raw_agents_input()
+    test_database['raw_agents'] = {'cols': raw_agent_cols,
+                                   'tuples': raw_agent_tuples,
+                                   'dict': raw_agent_dict}
+
+    reading_cols, reading_tuples, reading_dict = \
+        _make_readings_input()
+    test_database['reading'] = {'cols': reading_cols,
+                                'tuples': reading_tuples,
+                                'dict': reading_dict}
+
+    text_content_cols, text_content_tuples, text_content_dict = \
+        _make_text_content_input()
+    test_database['text_content'] = {'cols': text_content_cols,
+                                     'tuples': text_content_tuples,
+                                     'dict': text_content_dict}
+
+    text_ref_cols, text_ref_tuples, text_ref_dict = \
+        _make_text_ref_input()
+    test_database['text_ref'] = {'cols': text_ref_cols,
+                                 'tuples': text_ref_tuples,
+                                 'dict': text_ref_dict}
+    test_database['db_info'] = {'cols': [],
+                                'tuples': [],
+                                'dict': {}}
+    return test_database
+
+
+def _make_raw_statements_input():
+    raw_statement_cols = ('id', 'uuid', 'indra_version', 'mk_hash',
+                          'reading_id', 'db_info_id', 'type', 'json')
+    raw_statement_tuples = [(0, '0', '3.14', 0, 0, None, 'Activation',
+                             b'{"type": "Activation", "sub": {"name": "ESR1",'
+                             b'"db_refs": {"TEXT": "ER", "HGNC": "3467"}},'
+                             b'"obj": {"name": "MAGEE1",'
+                             b'"db_refs":'
+                             b'{"TEXT": "damage", "HGNC": "24934"}},'
+                             b'"evidence": [{"source_api": "rdr", "text":'
+                             b'"Our investigation made no new findings about'
+                             b'ER, leading to damage in our groups ability to'
+                             b'secure funding."}]}'),
+                            (1, '1', '3.14', 1, 1, None, 'IncreaseAmount',
+                             b'{"type": "IncreaseAmount", "sub":'
+                             b' {"name": "NPS", "db_refs":'
+                             b'{"TEXT": "NPs", "HGNC": "33940"}},'
+                             b'"obj": {"name": "IMPACT",'
+                             b'"db_refs":'
+                             b'{"TEXT": "impact", "HGNC": "20387"}},'
+                             b'"evidence": [{"source_api": "rdr", "text":'
+                             b'"Our inability to produce sufficient quantities'
+                             b' of NPs has made a troubling impact on the'
+                             b'future of our lab."}]}')]
+
+    raw_statement_dict = {x[0]: x for x in raw_statement_tuples}
+    return raw_statement_cols, raw_statement_tuples, raw_statement_dict
+
+
+def _make_raw_agents_input():
+    raw_agent_cols = ('id', 'stmt_id', 'db_name', 'db_id', 'role')
+    raw_agent_tuples = [(0, 0, 'TEXT', 'ER', 'SUBJECT'),
+                        (1, 0, 'HGNC', 'ESR1', 'SUBJECT'),
+                        (2, 1, 'TEXT', 'NPs', 'SUBJECT'),
+                        (3, 1, 'HGNC', '33940', 'SUBJECT'),
+                        (4, 0, 'TEXT', 'damage', 'OBJECT'),
+                        (5, 0, 'HGNC', '24934', 'OBJECT'),
+                        (6, 1, 'TEXT', 'impact', 'OBJECT'),
+                        (7, 1, 'HGNC', '20387', 'OBJECT')]
+
+    raw_agent_dict = {x[0]: x for x in raw_agent_tuples}
+    return raw_agent_cols, raw_agent_dict
+
+
+def _make_readings_input():
+    reading_cols = ('id', 'text_content_id', 'reader', 'reader_version',
+                    'bytes', 'format')
+    reading_tuples = [(0, 1, 'RDR', '2.78', b'\x1f', 'json'),
+                      (1, 2, 'RDR', '2.78', b'\x82', 'json')]
+    reading_dict = {x[0]: x for x in reading_tuples}
+    return reading_cols, reading_tuples, reading_dict
+
+
+def _make_text_content_input():
+    text_content_cols = ('id', 'text_ref_id', 'source', 'text_type', 'format',
+                         'content')
+    abstract0 = 'We investigate properties of the estrogen receptor (ER).'
+    fulltext0 = ('We investigate properties of the estrogen receptor (ER).'
+                 ' Our investigation made no new findings about ER, leading to'
+                 ' damage in our groups abilty to secure funding.')
+    abstract1 = ('We describe an experiment about nanoparticles (NPs).'
+                 ' The experiment was a complete failure. Our inability'
+                 ' to produce sufficient quantities of NPs has made a'
+                 ' troubling impact on the future of our lab.')
+    fulltext1 = ('We describe an experiment about nanoparticles (NPs).'
+                 ' The experiment was a complete failure. Our inability to'
+                 'produce sufficient quantities of NPs has made a troubling'
+                 ' impact on the future of our lab. The following figure'
+                 ' contains a schematic diagram of the apparatus of our'
+                 ' experiment.')
+
+    text_content_tuples = [(0, 0, 'pubmed', 'abstract', 'text', abstract0),
+                           (1, 0, 'pmc', 'fulltext', 'text', fulltext0),
+                           (2, 1, 'pubmed', 'abstract', 'text', abstract1),
+                           (3, 1, 'pmc', 'fulltext', 'text', fulltext1)]
+    text_content_dict = {x[0]: x for x in text_content_tuples}
+    return text_content_cols, text_content_tuples, text_content_dict
+
+
+def _make_text_ref_input():
+    text_ref_cols = ('id', 'pmid', 'pmcid', 'doi', 'manuscript_id', 'pii')
+    text_ref_tuples = [(0, '000000', 'PMC777777', None, None, None),
+                       (1, '777777', 'PMC000000', None, None, None)]
+    text_ref_dict = {x[0]: x for x in text_ref_tuples}
+    return text_ref_cols, text_ref_tuples, text_ref_dict

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -22,10 +22,12 @@ def test_get_stmts_with_agent_text_like():
     assert 'DL' in agent_stmts1
     assert agent_stmts1['ER'] == [0]
     assert agent_stmts1['DL'] == [2]
+
+    agent_stmts2 = get_stmts_with_agent_text_like('__s', filter_genes=True,
                                                   db=db)
-    assert len(agent_stmts1) == 1
-    assert 'NPs' in agent_stmts1
-    assert agent_stmts1['NPs'] == [1]
+    assert len(agent_stmts2) == 1
+    assert 'NPs' in agent_stmts2
+    assert agent_stmts2['NPs'] == [1]
 
 
 def test_get_stmts_with_agent_test_in():

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -30,7 +30,7 @@ def test_get_stmts_with_agent_text_like():
     assert agent_stmts2['NPs'] == [1]
 
 
-def test_get_stmts_with_agent_test_in():
+def test_get_stmts_with_agent_text_in():
     db = _get_prepped_db()
     agent_stmts = get_stmts_with_agent_text_in(['damage', 'impact'],
                                                filter_genes=True, db=db)

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -65,7 +65,8 @@ def _make_test_db_input():
 
 def _make_raw_statements_input():
     raw_statement_cols = ('id', 'uuid', 'indra_version', 'mk_hash',
-                          'reading_id', 'db_info_id', 'type', 'json')
+                          'reading_id', 'db_info_id', 'type', 'json',
+                          'batch_id', 'source_hash')
     raw_statement_tuples = [(0, '0', '3.14', 0, 0, None, 'Activation',
                              b'{"type": "Activation", "sub": {"name": "ESR1",'
                              b'"db_refs": {"TEXT": "ER", "HGNC": "3467"}},'

--- a/indra_db/tests/test_content_scripts.py
+++ b/indra_db/tests/test_content_scripts.py
@@ -1,7 +1,5 @@
-from .test_client import _PrePaDatabaseTestSetup
 
 
-class _DatabaseTestSetup(_PrePaDatabaseTestSetup):
     """Sets up the test database"""
     def __init__(self):
         raise NotImplementedError

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -21,8 +21,8 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False,
         For example '__' for two letter agents
 
     filter_genes : Optional[bool]
-       if True, only considers agents matching the pattern for which there
-       is an HGNC grounding
+       if True, only returns map for agent texts for which there is at least
+       one HGNC grounding in the database. Default: False
 
     db : Optional[:py:class:`DatabaseManager`]
         User has the option to pass in a database manager. If None
@@ -31,9 +31,10 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False,
     Returns
     -------
     dict
-        dict mapping agent texts matching the input pattern to lists of
-        ids for statements with at least one agent with raw text matching
-        the pattern.
+        dict mapping agent texts to statement ids. agent text are those
+        matching the input pattern. Each agent text maps to the list of
+        statement ids for statements containing an agent with that TEXT
+        in its db_refs
     """
     if db is None:
         db = get_primary_db()
@@ -67,8 +68,8 @@ def get_stmts_with_agent_text_in(texts, filter_genes=False, db=None):
         a list of agent texts
 
     filter_genes : Optional[bool]
-       if True, only considers agents matching the pattern for which there
-       is an HGNC grounding
+        if True, only returns map for agent texts for which there is at least
+        one HGNC grounding in the database. Default: False
 
     db : Optional[:py:class:`DatabaseManager`]
         User has the option to pass in a database manager. If None
@@ -77,8 +78,8 @@ def get_stmts_with_agent_text_in(texts, filter_genes=False, db=None):
     Returns
     -------
     dict
-        dict mapping agent texts to lists of stmt_ids for statements
-        containing an agent with the given text
+        dict mapping agent texts to lists of statement ids for statements
+        containing an agent with that TEXT in its db_refs.
     """
     if db is None:
         db = get_primary_db()
@@ -117,10 +118,16 @@ def get_text_content_from_stmt_ids(stmt_ids, db=None):
 
     Returns
     -------
-    dict of str: str
-        dictionary mapping statement ids to text content. Uses fulltext
-        if one is available, falls back upon using the abstract.
-        A statement id will map to None if no text content is available.
+    ref_dict: dict
+        dict mapping statement ids to associated text ref ids. Some
+        statement ids will map to None if there is no associated text
+        content.
+
+    text_dict: dict
+        dict mapping text ref ids to best possible text content.
+        fulltext xml from elsevier or pmc if it exists in the database,
+        otherwise an abstract if there is one in the database. Maps text_ref
+        to None if there is no text content available.
     """
     if db is None:
         db = get_primary_db()
@@ -165,7 +172,6 @@ def get_text_content_from_stmt_ids(stmt_ids, db=None):
     return ref_dict, text_dict
 
 
-
 def get_text_content_from_text_refs(text_refs, db=None):
     """Get text_content from an evidence object's text_refs attribute
 
@@ -180,7 +186,6 @@ def get_text_content_from_text_refs(text_refs, db=None):
     db : Optional[:py:class:`DatabaseManager`]
         User has the option to pass in a database manager. If None
         the primary database is used. Default: None
-        
 
     Returns
     -------

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -44,7 +44,7 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False):
         for stmt_id, db_id in text_dict:
             if stmt_id not in hgnc_stmts:
                 continue
-        hgnc_rawtexts.add(db_id)
+            hgnc_rawtexts.add(db_id)
 
     result_dict = defaultdict(list)
     for stmt_id, db_id in text_dict:
@@ -85,28 +85,30 @@ def get_text_content_from_stmt_ids(stmt_ids):
     abstracts = {text_id: unpack(text)
                  for text_id, text, text_type in texts
                  if text_type == 'abstract'}
-    result = {}
+    ref_dict = {}
+    text_dict = {}
     for stmt_id in stmt_ids:
         # first check if we have text content for this statement
         try:
             text_ref = text_refs[stmt_id]
         except KeyError:
             # if not, set fulltext to None
-            result[stmt_id] = None
+            ref_dict[stmt_id] = None
             continue
+        ref_dict[stmt_id] = text_ref
         fulltext = fulltexts.get(text_ref)
         abstract = abstracts.get(text_ref)
         # use the fulltext if we have one
         if fulltext is not None:
             # if so, the text content is xml and will need to be processed
-            result[stmt_id] = fulltext
+            text_dict[text_ref] = fulltext
         # otherwise use the abstract
         elif abstract is not None:
-            result[stmt_id] = abstract
+            text_dict[text_ref] = abstract
         # if we have neither, set result to None
         else:
-            result[stmt_id] = None
-    return result
+            text_dict[text_ref] = None
+    return ref_dict, text_ref_dict
 
 
 def get_text_content_from_text_refs(text_refs):

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -46,7 +46,8 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False,
     agent_stmts_dict = defaultdict(list)
     for agent_text, stmt_id in agents:
         agent_stmts_dict[agent_text].append(stmt_id)
-        agent_stmts_dict = dict(agent_stmts_dict)
+
+    agent_stmts_dict = dict(agent_stmts_dict)
     if not filter_genes:
         return agent_stmts_dict
     else:

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -242,3 +242,28 @@ def _extract_db_refs(stmt_json):
                 continue
             db_ref_list.append(db_refs)
     return db_ref_list
+
+def _get_hgnc_agents(db, agent_stmts_dict):
+    hgnc_agents = set()
+    unique_stmts = set(stmt_id for stmts in agent_stmts_dict.values()
+                       for stmt_id in stmts)
+    stmt_jsons = db.select_all([db.RawStatements.id,
+                                db.RawStatements.json],
+                               db.RawStatements.id.in_(unique_stmts))
+    json_dict = {stmt_id: json.loads(jsn) for stmt_id, jsn in stmt_jsons}
+    flag = False
+    for agent_text, stmts in agent_stmts_dict.items():
+        for stmt_id in stmts:
+            stmt_json = json_dict[stmt_id]
+            db_refs = _extract_db_refs(stmt_json)
+            for ref in db_refs:
+                if ('TEXT' in ref and 'HGNC' in ref and
+                        ref['TEXT'] == agent_text):
+                    hgnc_agents.add(agent_text)
+                    # if an agent text is determined to be grounded to HGNC
+                    # in at least one statement, break early
+                    flag = True
+                    break
+            if flag:
+                break
+    return hgnc_agents

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -163,7 +163,7 @@ def get_text_content_from_stmt_ids(stmt_ids):
         # if we have neither, set result to None
         else:
             text_dict[text_ref] = None
-    return ref_dict, text_ref_dict
+    return ref_dict, text_dict
 
 
 def get_text_content_from_text_refs(text_refs):

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -39,23 +39,15 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False,
     if db is None:
         db = get_primary_db()
 
+    # Query Raw agents table for agents with TEXT db_ref matching pattern
+    # Selects agent texts, statement ids and agent numbers. The agent number
+    # corresponds to the agents index into the agent list
     agents = db.select_all([db.RawAgents.db_id,
-                            db.RawAgents.stmt_id],
+                            db.RawAgents.stmt_id,
+                            db.RawAgents.ag_num],
                            db.RawAgents.db_name.like('TEXT'),
                            db.RawAgents.db_id.like(pattern),
                            db.RawAgents.stmt_id.isnot(None))
-    agent_stmts_dict = defaultdict(list)
-    for agent_text, stmt_id in agents:
-        agent_stmts_dict[agent_text].append(stmt_id)
-
-    agent_stmts_dict = dict(agent_stmts_dict)
-    if not filter_genes:
-        return agent_stmts_dict
-    else:
-        hgnc_agents = _get_hgnc_agents(db, agent_stmts_dict)
-        output = {agent: stmts for agent, stmts in agent_stmts_dict.items()
-                  if agent in hgnc_agents}
-        return output
 
 
 def get_stmts_with_agent_text_in(texts, filter_genes=False, db=None):

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -41,7 +41,7 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False,
 
     agents = db.select_all([db.RawAgents.db_id,
                             db.RawAgents.stmt_id],
-                           db.RawAgents.db_name == 'TEXT',
+                           db.RawAgents.db_name.like('TEXT'),
                            db.RawAgents.db_id.like(pattern),
                            db.RawAgents.stmt_id.isnot(None))
     agent_stmts_dict = defaultdict(list)

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -9,7 +9,8 @@ from .constructors import get_primary_db
 from .helpers import unpack, _get_trids
 
 
-def get_stmts_with_agent_text_like(pattern, filter_genes=False):
+def get_stmts_with_agent_text_like(pattern, filter_genes=False,
+                                   db=None):
     """Get statement ids with agent with rawtext matching pattern
 
 
@@ -23,6 +24,10 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False):
        if True, only considers agents matching the pattern for which there
        is an HGNC grounding
 
+    db : Optional[:py:class:`DatabaseManager`]
+        User has the option to pass in a database manager. If None
+        the primary database is used. Default: None
+
     Returns
     -------
     dict
@@ -30,7 +35,8 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False):
         ids for statements with at least one agent with raw text matching
         the pattern.
     """
-    db = get_primary_db()
+    if db is None:
+        db = get_primary_db()
 
     agents = db.select_all([db.RawAgents.db_id,
                             db.RawAgents.stmt_id],
@@ -40,7 +46,7 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False):
     agent_stmts_dict = defaultdict(list)
     for agent_text, stmt_id in agents:
         agent_stmts_dict[agent_text].append(stmt_id)
-    agent_stmts_dict = dict(agent_stmts_dict)
+        agent_stmts_dict = dict(agent_stmts_dict)
     if not filter_genes:
         return agent_stmts_dict
     else:
@@ -50,7 +56,7 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False):
         return output
 
 
-def get_stmts_with_agent_text_in(texts, filter_genes=False):
+def get_stmts_with_agent_text_in(texts, filter_genes=False, db=None):
     """Get statement ids with agent with rawtext in list
 
 
@@ -63,13 +69,19 @@ def get_stmts_with_agent_text_in(texts, filter_genes=False):
        if True, only considers agents matching the pattern for which there
        is an HGNC grounding
 
+    db : Optional[:py:class:`DatabaseManager`]
+        User has the option to pass in a database manager. If None
+        the primary database is used. Default: None
+
     Returns
     -------
     dict
         dict mapping agent texts to lists of stmt_ids for statements
         containing an agent with the given text
     """
-    db = get_primary_db()
+    if db is None:
+        db = get_primary_db()
+
     agents = db.select_all([db.RawAgents.db_id,
                             db.RawAgents.stmt_id],
                            db.RawAgents.db_name == 'TEXT',
@@ -87,7 +99,7 @@ def get_stmts_with_agent_text_in(texts, filter_genes=False):
                 if agent in hgnc_agents}
 
 
-def get_text_content_from_stmt_ids(stmt_ids):
+def get_text_content_from_stmt_ids(stmt_ids, db=None):
     """Get text content for statements from a list of ids
 
     Gets the fulltext if it is available, even if the statement came from an
@@ -97,6 +109,11 @@ def get_text_content_from_stmt_ids(stmt_ids):
     ----------
     stmt_ids : list of str
 
+    db : Optional[:py:class:`DatabaseManager`]
+        User has the option to pass in a database manager. If None
+        the primary database is used. Default: None
+
+
     Returns
     -------
     dict of str: str
@@ -104,7 +121,9 @@ def get_text_content_from_stmt_ids(stmt_ids):
         if one is available, falls back upon using the abstract.
         A statement id will map to None if no text content is available.
     """
-    db = get_primary_db()
+    if db is None:
+        db = get_primary_db()
+
     text_refs = db.select_all([db.RawStatements.id, db.TextRef.id],
                               db.RawStatements.id.in_(stmt_ids),
                               *db.link(db.RawStatements, db.TextRef))
@@ -145,7 +164,8 @@ def get_text_content_from_stmt_ids(stmt_ids):
     return ref_dict, text_dict
 
 
-def get_text_content_from_text_refs(text_refs):
+
+def get_text_content_from_text_refs(text_refs, db=None):
     """Get text_content from an evidence object's text_refs attribute
 
 
@@ -156,6 +176,11 @@ def get_text_content_from_text_refs(text_refs):
         The dictionary should be keyed on id_types. The valid keys
         are 'PMID', 'PMCID', 'DOI', 'PII', 'URL', 'MANUSCRIPT_ID'.
 
+    db : Optional[:py:class:`DatabaseManager`]
+        User has the option to pass in a database manager. If None
+        the primary database is used. Default: None
+        
+
     Returns
     -------
     text : str
@@ -163,7 +188,9 @@ def get_text_content_from_text_refs(text_refs):
         database, otherwise the abstract. Returns None if no content
         exists for the text_refs in the database
     """
-    db = get_primary_db()
+    if db is None:
+        db = get_primary_db()
+
     text_ref_id = None
     for id_type in ['pmid', 'pmcid', 'doi',
                     'pii', 'url', 'manuscript_id']:

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -65,12 +65,15 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False,
         if stmt_id not in output[agent_text]:
             output[agent_text].append(stmt_id)
     return dict(output)
+
+
+def get_stmts_with_agent_text_in(agent_texts, filter_genes=False, db=None):
     """Get statement ids with agent with rawtext in list
 
 
     Parameters
     ----------
-    tests : list of str
+    agent_texts : list of str
         a list of agent texts
 
     filter_genes : Optional[bool]

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -155,3 +155,30 @@ def get_text_content_from_text_refs(text_refs):
     if abstract:
         return abstract[0]
     return None
+
+
+def _extract_db_refs(stmt_json):
+    agent_types = ['subj', 'obj', 'enz', 'agent', 'gef;', 'ras',
+                   'gap', 'obj_from', 'obj_to']
+    db_ref_list = []
+
+    for agent_type in agent_types:
+        try:
+            agent = stmt_json[agent_type]
+        except KeyError:
+            continue
+        try:
+            db_refs = agent['db_refs']
+        except KeyError:
+            continue
+        db_ref_list.append(db_refs)
+
+    members = stmt_json.get('members')
+    if members is not None:
+        for member in members:
+            try:
+                db_refs = member['db_refs']
+            except KeyError:
+                continue
+            db_ref_list.append(db_refs)
+    return db_ref_list

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -86,7 +86,7 @@ def get_stmts_with_agent_text_in(texts, filter_genes=False, db=None):
 
     agents = db.select_all([db.RawAgents.db_id,
                             db.RawAgents.stmt_id],
-                           db.RawAgents.db_name == 'TEXT',
+                           db.RawAgents.db_name.like('TEXT'),
                            db.RawAgents.stmt_id.isnot(None))
     agent_stmts_dict = defaultdict(list)
     for agent_text, stmt_id in agents:


### PR DESCRIPTION
This PR temporarily concludes work on content scripts for use in deft disambiguation. 

A new function has been added, get_stmts_with_agent_texts_in that returns dictionaries mapping agent texts to lists of containing statements. This function is similar to get_stmts_with_agent_texts_like and is useful for things such as finding all common words from a list that are being grounded by a reader.

For both get_stmts_agent_texts_in and get_stmts_with_agent_texts_like, filtering to only agent texts that have received at least one HGNC grounding in the database now works correctly. The previous implementation was not stringent enough and included agent texts that were contained in statements where at least one agent had an HGNC grounding. The new implementation checks the db_refs of the corresponding statement jsons.

get_text_content_from_stmt_ids now returns two dictionaries instead of one. The first dictionary maps statement ids to text_ref ids, the latter dictionary maps text_ref_ids to the best available text content for that id. This dramatically shrinks output size, since the previous implementation included mappings of statement ids directly to text content, duplicating the content containing multiple statements.

Tests have been written for all functions using a test database constructed from tuples as in other database tests.