### PR TITLE
Breakup lookup

### DIFF
--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -249,8 +249,9 @@ def get_statement_jsons_from_agents(agents=None, stmt_type=None, db=None,
         db = get_primary_db()
 
     # TODO: Extend this to allow retrieval of raw statements.
-    mk_hash_c = db.PaMeta.mk_hash.label('mk_hash')
-    ev_count_c = db.PaMeta.ev_count.label('ev_count')
+    def labelled_hash_and_count(meta):
+        return meta.mk_hash.label('mk_hash'), meta.ev_count.label('ev_count')
+
     queries = []
     for role, ag_dbid, ns in agents:
         # Make the id match paradigms for the database.
@@ -260,17 +261,17 @@ def get_statement_jsons_from_agents(agents=None, stmt_type=None, db=None,
         # If we are looking for a name...
         if ns == 'NAME':
             q = (db.session
-                 .query(mk_hash_c, ev_count_c)
+                 .query(*labelled_hash_and_count(db.NameMeta))
                  .filter(db.NameMeta.db_id.like(ag_dbid)))
             meta = db.NameMeta
         elif ns == 'TEXT':
             q = (db.session
-                 .query(mk_hash_c, ev_count_c)
+                 .query(*labelled_hash_and_count(db.TextMeta))
                  .filter(db.TextMeta.db_id.like(ag_dbid)))
             meta = db.TextMeta
         else:
             q = (db.session
-                 .query(mk_hash_c, ev_count_c)
+                 .query(*labelled_hash_and_count(db.OtherMeta))
                  .filter(db.OtherMeta.db_id.like(ag_dbid),
                          db.OtherMeta.db_name.like(ns)))
             meta = db.OtherMeta

--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -257,15 +257,29 @@ def get_statement_jsons_from_agents(agents=None, stmt_type=None, db=None,
         ag_dbid = regularize_agent_id(ag_dbid, ns)
 
         # Create this query (for this agent)
-        q = (db.session
-             .query(mk_hash_c, ev_count_c)
-             .filter(db.PaMeta.db_id.like(ag_dbid),
-                     db.PaMeta.db_name.like(ns)))
+        # If we are looking for a name...
+        if ns == 'NAME':
+            q = (db.session
+                 .query(mk_hash_c, ev_count_c)
+                 .filter(db.NameMeta.db_id.like(ag_dbid)))
+            meta = db.NameMeta
+        elif ns == 'TEXT':
+            q = (db.session
+                 .query(mk_hash_c, ev_count_c)
+                 .filter(db.TextMeta.db_id.like(ag_dbid)))
+            meta = db.TextMeta
+        else:
+            q = (db.session
+                 .query(mk_hash_c, ev_count_c)
+                 .filter(db.OtherMeta.db_id.like(ag_dbid),
+                         db.OtherMeta.db_name.like(ns)))
+            meta = db.OtherMeta
+
         if stmt_type is not None:
-            q = q.filter(db.PaMeta.type.like(stmt_type))
+            q = q.filter(meta.type.like(stmt_type))
 
         if role is not None:
-            q = q.filter(db.PaMeta.role == role.upper())
+            q = q.filter(meta.role == role.upper())
 
         # Intersect with the previous query.
         queries.append(q)

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -681,6 +681,14 @@ class DatabaseManager(object):
         self.NameMeta = NameMeta
         self.m_views[NameMeta.__tablename__] = NameMeta
 
+        class OtherMeta(self.Base, NamespaceLookup):
+            __tablename__ = 'other_meta'
+            __definition__ = ("SELECT db_name, db_id, ag_id, role, ag_num, "
+                              "type, mk_hash, ev_count FROM pa_meta "
+                              "WHERE db_name NOT IN ('NAME', 'TEXT');")
+        self.OtherMeta = OtherMeta
+        self.m_views[OtherMeta.__tablename__] = OtherMeta
+
         class RawStmtSrc(self.Base, MaterializedView):
             __tablename__ = 'raw_stmt_src'
             __definition__ = ('SELECT raw_statements.id AS sid, '
@@ -874,8 +882,8 @@ class DatabaseManager(object):
 
     def manage_views(self, mode, view_list=None, with_data=True):
         ordered_views = ['fast_raw_pa_link', 'evidence_counts', 'pa_meta',
-                         'name_meta', 'text_meta', 'raw_stmt_src',
-                         'pa_stmt_src']
+                         'name_meta', 'text_meta', 'other_meta',
+                         'raw_stmt_src', 'pa_stmt_src']
         other_views = {'reading_ref_link'}
         active_views = self.get_active_views()
 

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -701,7 +701,7 @@ class DatabaseManager(object):
             __tablename__ = 'other_meta'
             __definition__ = ("SELECT db_name, db_id, ag_id, role, ag_num, "
                               "type, mk_hash, ev_count FROM pa_meta "
-                              "WHERE db_name NOT IN ('NAME', 'TEXT');")
+                              "WHERE db_name NOT IN ('NAME', 'TEXT')")
             ag_id = Column(Integer, primary_key=True)
             db_name = Column(String)
             db_id = Column(String)

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -164,7 +164,6 @@ class MaterializedView(Displayable):
 
     @classmethod
     def create(cls, db, with_data=True, commit=True):
-        print('here')
         sql = "CREATE MATERIALIZED VIEW public.%s AS %s WITH %s DATA;" \
               % (cls.__tablename__, cls.get_definition(),
                  '' if with_data else "NO")

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -695,7 +695,11 @@ class DatabaseManager(object):
         self.NameMeta = NameMeta
         self.m_views[NameMeta.__tablename__] = NameMeta
 
-        class OtherMeta(self.Base, NamespaceLookup):
+        class OtherMeta(self.Base, MaterializedView):
+            __tablename__ = 'other_meta'
+            __definition__ = ("SELECT db_name, db_id, ag_id, role, ag_num, "
+                              "type, mk_hash, ev_count FROM pa_meta "
+                              "WHERE db_name NOT IN ('NAME', 'TEXT');")
             ag_id = Column(Integer, primary_key=True)
             db_name = Column(String)
             db_id = Column(String)
@@ -704,10 +708,6 @@ class DatabaseManager(object):
             mk_hash = Column(BigInteger, ForeignKey('fast_raw_pa_link.mk_hash'))
             raw_pa_link = relationship(FastRawPaLink)
             ev_count = Column(Integer)
-            __tablename__ = 'other_meta'
-            __definition__ = ("SELECT db_name, db_id, ag_id, role, ag_num, "
-                              "type, mk_hash, ev_count FROM pa_meta "
-                              "WHERE db_name NOT IN ('NAME', 'TEXT');")
         self.OtherMeta = OtherMeta
         self.m_views[OtherMeta.__tablename__] = OtherMeta
 

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -643,7 +643,7 @@ class DatabaseManager(object):
                               'pa_agents.id AS ag_id, pa_agents.role, '
                               'pa_agents.ag_num, pa_statements.type, '
                               'pa_statements.mk_hash, evidence_counts.ev_count '
-                              'FROM pa_agents, pa_statements,evidence_counts '
+                              'FROM pa_agents, pa_statements, evidence_counts '
                               'WHERE pa_agents.stmt_mk_hash = pa_statements.mk_hash '
                               'AND pa_statements.mk_hash = evidence_counts.mk_hash')
             ag_id = Column(Integer, primary_key=True)
@@ -656,6 +656,15 @@ class DatabaseManager(object):
             ev_count = Column(Integer)
         self.PaMeta = PaMeta
         self.m_views[PaMeta.__tablename__] = PaMeta
+
+        class TextMeta(self.Base, MaterializedView):
+            __tablename__ = 'text_meta'
+            __definition__ = ("SELECT db_id, ag_id, role, ag_num, type, "
+                              "mk_hash, ev_count "
+                              "FROM pa_meta "
+                              "WHERE db_name = 'TEXT';")
+        self.TextMeta = TextMeta
+        self.m_views[TextMeta.__tablename__] = TextMeta
 
         class RawStmtSrc(self.Base, MaterializedView):
             __tablename__ = 'raw_stmt_src'

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -672,16 +672,38 @@ class DatabaseManager(object):
         class TextMeta(self.Base, NamespaceLookup):
             __tablename__ = 'text_meta'
             __dbname__ = 'TEXT'
+            ag_id = Column(Integer, primary_key=True)
+            db_id = Column(String)
+            role = Column(String(20))
+            type = Column(String(100))
+            mk_hash = Column(BigInteger, ForeignKey('fast_raw_pa_link.mk_hash'))
+            raw_pa_link = relationship(FastRawPaLink)
+            ev_count = Column(Integer)
         self.TextMeta = TextMeta
         self.m_views[TextMeta.__tablename__] = TextMeta
 
         class NameMeta(self.Base, NamespaceLookup):
             __tablename__ = 'name_meta'
             __dbname__ = 'NAME'
+            ag_id = Column(Integer, primary_key=True)
+            db_id = Column(String)
+            role = Column(String(20))
+            type = Column(String(100))
+            mk_hash = Column(BigInteger, ForeignKey('fast_raw_pa_link.mk_hash'))
+            raw_pa_link = relationship(FastRawPaLink)
+            ev_count = Column(Integer)
         self.NameMeta = NameMeta
         self.m_views[NameMeta.__tablename__] = NameMeta
 
         class OtherMeta(self.Base, NamespaceLookup):
+            ag_id = Column(Integer, primary_key=True)
+            db_name = Column(String)
+            db_id = Column(String)
+            role = Column(String(20))
+            type = Column(String(100))
+            mk_hash = Column(BigInteger, ForeignKey('fast_raw_pa_link.mk_hash'))
+            raw_pa_link = relationship(FastRawPaLink)
+            ev_count = Column(Integer)
             __tablename__ = 'other_meta'
             __definition__ = ("SELECT db_name, db_id, ag_id, role, ag_num, "
                               "type, mk_hash, ev_count FROM pa_meta "

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -874,7 +874,8 @@ class DatabaseManager(object):
 
     def manage_views(self, mode, view_list=None, with_data=True):
         ordered_views = ['fast_raw_pa_link', 'evidence_counts', 'pa_meta',
-                         'raw_stmt_src', 'pa_stmt_src']
+                         'name_meta', 'text_meta', 'raw_stmt_src',
+                         'pa_stmt_src']
         other_views = {'reading_ref_link'}
         active_views = self.get_active_views()
 

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -641,8 +641,8 @@ class DatabaseManager(object):
             __tablename__ = 'pa_meta'
             __definition__ = ('SELECT pa_agents.db_name, pa_agents.db_id, '
                               'pa_agents.id AS ag_id, pa_agents.role, '
-                              'pa_statements.type, pa_statements.mk_hash, '
-                              'evidence_counts.ev_count '
+                              'pa_agents.ag_num, pa_statements.type, '
+                              'pa_statements.mk_hash, evidence_counts.ev_count '
                               'FROM pa_agents, pa_statements,evidence_counts '
                               'WHERE pa_agents.stmt_mk_hash = pa_statements.mk_hash '
                               'AND pa_statements.mk_hash = evidence_counts.mk_hash')

--- a/indra_db/managers/materialized_view_manager.py
+++ b/indra_db/managers/materialized_view_manager.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '-D', '--database',
         default='primary',
-        help=('Select a database from the names given in the config or '
+        help=('Choose a database from the names given in the config or '
               'environment, for example primary is INDRA_DB_PRIMAY in the '
               'config file and INDRADBPRIMARY in the environment. The default '
               'is \'primary\'.')


### PR DESCRIPTION
Break out separate tables for NAME and TEXT lookups, and create a separate meta table with all the other metadata. This division of labor should significantly improve lookup times. This PR also implements some basic Index support for materialized views.