### PR TITLE
Quick remake of sif dumper

### DIFF
--- a/indra_db/tests/test_sif_dumper.py
+++ b/indra_db/tests/test_sif_dumper.py
@@ -1,0 +1,85 @@
+import unittest
+import numpy as np
+from os import path, remove
+import pandas as pd
+
+import indra_db.tests.util as tu
+from indra_db.util.dump_sif import load_db_content, make_ev_strata, \
+    make_dataframe, NS_LIST
+
+# Get db
+db = tu.get_db_with_views(1000)
+
+
+class SifDumperTester(unittest.TestCase):
+    def setUp(self):
+        self.db = db
+        self.db_content = load_db_content(True, NS_LIST, None, self.db)
+        self.df = make_dataframe(True, self.db_content, None)
+
+    # Tests
+    def test_get_content(self):
+        """Checks content loading and its structure"""
+
+        # Get first item
+        r = list(self.db_content)[0]
+        assert isinstance(r, tuple)
+        assert len(r) == 6
+        assert isinstance(r[0], int)  # mk_hash
+        assert isinstance(r[1], str)  # db_name
+        assert r[1] in NS_LIST
+        assert isinstance(r[2], str)  # db_id
+        assert isinstance(r[3], int)  # ag_num
+        assert r[3] > -1
+        assert isinstance(r[4], int)  # ev_count
+        assert r[4] > 0
+        assert isinstance(r[5], str)  # type
+
+    def test_dataframe(self):
+        """Checks a dataframe produced by make_dataframe"""
+
+        # Check column names
+        assert {'agA_id', 'agA_name', 'agA_ns', 'agB_id', 'agB_name', 'agB_ns',
+                'evidence_count', 'hash', 'stmt_type'} == set(self.df.columns)
+
+        # Check for None's
+        assert sum(self.df['agA_name'] == None) == 0
+        assert sum(self.df['agB_name'] == None) == 0
+
+        # Check df types
+        assert isinstance(self.df.head(1)['agA_ns'][0], str)
+        assert isinstance(self.df.head(1)['agB_ns'][0], str)
+        assert isinstance(self.df.head(1)['agA_id'][0], str)
+        assert isinstance(self.df.head(1)['agB_id'][0], str)
+        assert isinstance(self.df.head(1)['agA_name'][0], str)
+        assert isinstance(self.df.head(1)['agB_name'][0], str)
+        assert isinstance(self.df.head(1)['stmt_type'][0], str)
+        assert isinstance(self.df.head(1)['evidence_count'][0], np.int64)
+        assert isinstance(self.df.head(1)['hash'][0], np.int64)
+
+        # Check that we don't have significant keyerrors from creating the df
+        key_error_file = path.join(path.dirname(__file__), 'key_errors.csv')
+        if path.exists(key_error_file):
+            key_errors = pd.read_csv(key_error_file, sep=',',
+                                     names=['hash', 'ag_num'], header=None)
+            remove(key_error_file)
+            missing_hashes = set(key_errors['hash'].values)
+            df_hashes = set(self.df['hash'].values)
+
+            assert len(missing_hashes.intersection(df_hashes)) / \
+                len(df_hashes) < 0.5
+
+    def test_stratified_evidence(self):
+        """Check the stratified evidence dumper"""
+
+        ev_dict = make_ev_strata(db=self.db)
+
+        # Check if nested dict
+        for k in ev_dict:
+            assert isinstance(ev_dict[k], dict)
+            break
+
+        # Check that some keys exist in the df
+        df_hashes = set(self.df['hash'].values)
+        sd_hashes = set(ev_dict.keys())
+        assert len(sd_hashes.intersection(df_hashes)) / len(sd_hashes) > 0.25

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -66,6 +66,27 @@ def load_db_content(pkl_filename, reload, ns_list):
     return results
 
 
+def make_ev_strata(pkl_filename):
+
+    """Returns a dict of dicts with evidence count per source, per statement
+
+    The dictionary is at the top level keyed by statement hash and each
+    entry contains a dictionary keyed by the source that support the
+    statement where the entries are the evidence count for that source."""
+    db = dbu.get_primary_db()
+    res = db.select_all(db.PaStmtSrc)
+    ev = {}
+    for r in res:
+        rd = r.__dict__
+        ev[rd['mk_hash']] = {k: v for k, v in rd.items() if
+                             k not in ['_sa_instance_state', 'mk_hash'] and
+                             rd[k] is not None}
+
+    with open(pkl_filename, 'wb') as f:
+        pickle.dump(ev, f)
+    return ev
+
+
 def make_dataframe(pkl_filename, reconvert, db_content):
     if reconvert:
         # Organize by statement

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -1,4 +1,4 @@
-__all__ = ['load_db_content', 'make_dataframe']
+__all__ = ['load_db_content', 'make_dataframe', 'make_ev_strata', 'NS_LIST']
 
 import sys
 import pickle
@@ -82,7 +82,7 @@ def make_ev_strata(pkl_filename=None, db=None):
     return ev
 
 
-def make_dataframe(pkl_filename, reconvert, db_content):
+def make_dataframe(reconvert, db_content, pkl_filename=None):
     if reconvert:
         # Organize by statement
         logger.info("Organizing by statement...")
@@ -172,11 +172,16 @@ def make_dataframe(pkl_filename, reconvert, db_content):
                     f.write('%s,%s\n' % kn)
         df = pd.DataFrame.from_dict(rows)
 
-        with open(pkl_filename, 'wb') as f:
-            pickle.dump(df, f)
+        if pkl_filename:
+            with open(pkl_filename, 'wb') as f:
+                pickle.dump(df, f)
     else:
-        with open(pkl_filename, 'rb') as f:
-            df = pickle.load(f)
+        if not pkl_filename:
+            logger.error('Have to provide pickle file if not reconverting')
+            raise FileExistsError
+        else:
+            with open(pkl_filename, 'rb') as f:
+                df = pickle.load(f)
     return df
 
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -34,10 +34,11 @@ NS_PRIORITY_LIST = (
 NS_LIST = ('NAME', 'HGNC', 'FPLX', 'GO', 'MESH', 'HMDB', 'CHEBI', 'PUBCHEM')
 
 
-def load_db_content(reload, ns_list, pkl_filename=None):
+def load_db_content(reload, ns_list, pkl_filename=None, db=None):
     # Get the raw data
     if reload:
-        db = dbu.get_primary_db()
+        if not db:
+            db = dbu.get_primary_db()
         logger.info("Querying the database for statement metadata...")
         results = []
         for ns in ns_list:
@@ -59,13 +60,14 @@ def load_db_content(reload, ns_list, pkl_filename=None):
     return results
 
 
-def make_ev_strata(pkl_filename=None):
+def make_ev_strata(pkl_filename=None, db=None):
     """Returns a dict of dicts with evidence count per source, per statement
 
     The dictionary is at the top level keyed by statement hash and each
     entry contains a dictionary keyed by the source that support the
     statement where the entries are the evidence count for that source."""
-    db = dbu.get_primary_db()
+    if not db:
+        db = dbu.get_primary_db()
     res = db.select_all(db.PaStmtSrc)
     ev = {}
     for r in res:

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -33,17 +33,6 @@ NS_PRIORITY_LIST = (
 # NS_PRIORITY_LIST above
 NS_LIST = ('NAME', 'HGNC', 'FPLX', 'GO', 'MESH', 'HMDB', 'CHEBI', 'PUBCHEM')
 
-def format_agent(db_nm, db_id):
-    if db_nm == 'FPLX':
-        return db_id
-    elif db_nm == 'HGNC':
-        return hgnc_client.get_hgnc_name(db_id)
-    elif db_nm == 'GO':
-        norm_go_id = db_id[3:] if db_id.startswith('GO:GO:') else db_id
-        return go_client.get_go_label(norm_go_id)
-    elif db_nm == 'MESH':
-        return mesh_client.get_mesh_name(db_id)
-    return '{db_nm}:{db_id}'.format(db_nm=db_nm, db_id=db_id)
 
 def load_db_content(reload, ns_list, pkl_filename=None):
     # Get the raw data
@@ -71,7 +60,6 @@ def load_db_content(reload, ns_list, pkl_filename=None):
 
 
 def make_ev_strata(pkl_filename=None):
-
     """Returns a dict of dicts with evidence count per source, per statement
 
     The dictionary is at the top level keyed by statement hash and each
@@ -106,8 +94,7 @@ def make_dataframe(pkl_filename, reconvert, db_content):
                 stmt_info[h] = {'agents': [], 'ev_count': n, 'type': t}
             stmt_info[h]['agents'].append((num, db_nm, db_id))
         # Turn into dataframe with geneA, geneB, type, indexed by hash;
-        # expand out all complexes
-        # to multiple rows
+        # expand out complexes to multiple rows
 
         # Organize by pairs of genes, counting evidence.
         nkey_errors = 0

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -45,28 +45,28 @@ def format_agent(db_nm, db_id):
         return mesh_client.get_mesh_name(db_id)
     return '{db_nm}:{db_id}'.format(db_nm=db_nm, db_id=db_id)
 
-
-def load_db_content(pkl_filename, reload, ns_list):
+def load_db_content(reload, ns_list, pkl_filename=None):
     # Get the raw data
     if reload:
         db = dbu.get_primary_db()
-        print("Querying the database for statement metadata...")
+        logger.info("Querying the database for statement metadata...")
         results = []
         for ns in ns_list:
-            print("Querying for {ns}".format(ns=ns))
+            logger.info("Querying for {ns}".format(ns=ns))
             res = db.select_all([db.PaMeta.mk_hash, db.PaMeta.db_name,
                                  db.PaMeta.db_id, db.PaMeta.role,
                                  db.PaMeta.ev_count, db.PaMeta.type],
                                  db.PaMeta.db_name.like(ns))
             results.extend(res)
         results = set(results)
-        with open(pkl_filename, 'wb') as f:
-            pickle.dump(results, f)
-    else:
-        print("Loading database content from %s" % pkl_filename)
+        if pkl_filename:
+            with open(pkl_filename, 'wb') as f:
+                pickle.dump(results, f)
+    elif pkl_filename:
+        logger.info("Loading database content from %s" % pkl_filename)
         with open(pkl_filename, 'rb') as f:
             results = pickle.load(f)
-    print("{len} stmts loaded".format(len=len(results)))
+    logger.info("{len} stmts loaded".format(len=len(results)))
     return results
 
 
@@ -95,7 +95,7 @@ def make_ev_strata(pkl_filename=None):
 def make_dataframe(pkl_filename, reconvert, db_content):
     if reconvert:
         # Organize by statement
-        print("Organizing by statement...")
+        logger.info("Organizing by statement...")
         stmt_info = {}
         roles = {'SUBJECT':0, 'OBJECT':1, 'OTHER':2}
         for h, db_nm, db_id, r, n, t in db_content:
@@ -108,7 +108,7 @@ def make_dataframe(pkl_filename, reconvert, db_content):
 
         # Organize by pairs of genes, counting evidence.
         rows = []
-        print("Converting to pairwise entries...")
+        logger.info("Converting to pairwise entries...")
         for hash, info_dict in stmt_info.items():
             # Find roles with more than one agent
             agents_by_role = {}

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -110,6 +110,8 @@ def make_dataframe(pkl_filename, reconvert, db_content):
         # to multiple rows
 
         # Organize by pairs of genes, counting evidence.
+        nkey_errors = 0
+        error_keys = []
         rows = []
         logger.info("Converting to pairwise entries...")
         for hash, info_dict in stmt_info.items():
@@ -171,7 +173,14 @@ def make_dataframe(pkl_filename, reconvert, db_content):
                         ('evidence_count', info_dict['ev_count']),
                         ('hash', hash)])
                 rows.append(row)
-
+        if nkey_errors:
+            ef = 'key_errors.csv'
+            logger.warning('%d KeyErrors. Offending keys found in %s' %
+                           (nkey_errors, ef))
+            with open(ef, 'w') as f:
+                f.write('hash,PaMeta.ag_num\n')
+                for kn in error_keys:
+                    f.write('%s,%s\n' % kn)
         df = pd.DataFrame.from_dict(rows)
 
         with open(pkl_filename, 'wb') as f:

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -66,7 +66,7 @@ def load_db_content(pkl_filename, reload, ns_list):
     return results
 
 
-def make_ev_strata(pkl_filename):
+def make_ev_strata(pkl_filename=None):
 
     """Returns a dict of dicts with evidence count per source, per statement
 
@@ -82,8 +82,9 @@ def make_ev_strata(pkl_filename):
                              k not in ['_sa_instance_state', 'mk_hash'] and
                              rd[k] is not None}
 
-    with open(pkl_filename, 'wb') as f:
-        pickle.dump(ev, f)
+    if pkl_filename:
+        with open(pkl_filename, 'wb') as f:
+            pickle.dump(ev, f)
     return ev
 
 


### PR DESCRIPTION
This PR adds some functionality to `indra_db/util/dump_sif.py`. Particularly: argparse options as well as adding 'NAME' to the queried namespaces, allowing the final dataframe to contain the canonical name used in the database alongside the grounded ns and id for the agent.

Tests are also added.