### PR TITLE
Update sif dumper

### DIFF
--- a/indra_db/resources/source_mapping.json
+++ b/indra_db/resources/source_mapping.json
@@ -1,5 +1,5 @@
 {
     "cbn": "bel",
     "bel_lc": "bel",
-    "pc11": "phosphosite"
+    "pc11": "biopax"
 }

--- a/indra_db/resources/source_mapping.json
+++ b/indra_db/resources/source_mapping.json
@@ -1,0 +1,5 @@
+{
+    "cbn": "bel",
+    "bel_lc": "bel",
+    "pc11": "phosphosite"
+}

--- a/indra_db/tests/test_sif_dumper.py
+++ b/indra_db/tests/test_sif_dumper.py
@@ -40,7 +40,8 @@ class SifDumperTester(unittest.TestCase):
 
         # Check column names
         assert {'agA_id', 'agA_name', 'agA_ns', 'agB_id', 'agB_name', 'agB_ns',
-                'evidence_count', 'hash', 'stmt_type'} == set(self.df.columns)
+                'evidence_count', 'stmt_hash', 'stmt_type'} == set(
+            self.df.columns)
 
         # Check for None's
         assert sum(self.df['agA_name'] == None) == 0
@@ -55,16 +56,16 @@ class SifDumperTester(unittest.TestCase):
         assert isinstance(self.df.head(1)['agB_name'][0], str)
         assert isinstance(self.df.head(1)['stmt_type'][0], str)
         assert isinstance(self.df.head(1)['evidence_count'][0], np.int64)
-        assert isinstance(self.df.head(1)['hash'][0], np.int64)
+        assert isinstance(self.df.head(1)['stmt_hash'][0], np.int64)
 
         # Check that we don't have significant keyerrors from creating the df
         key_error_file = path.join(path.dirname(__file__), 'key_errors.csv')
         if path.exists(key_error_file):
             key_errors = pd.read_csv(key_error_file, sep=',',
-                                     names=['hash', 'ag_num'], header=None)
+                                     names=['stmt_hash', 'ag_num'], header=None)
             remove(key_error_file)
-            missing_hashes = set(key_errors['hash'].values)
-            df_hashes = set(self.df['hash'].values)
+            missing_hashes = set(key_errors['stmt_hash'].values)
+            df_hashes = set(self.df['stmt_hash'].values)
 
             assert len(missing_hashes.intersection(df_hashes)) / \
                 len(df_hashes) < 0.5
@@ -80,6 +81,6 @@ class SifDumperTester(unittest.TestCase):
             break
 
         # Check that some keys exist in the df
-        df_hashes = set(self.df['hash'].values)
+        df_hashes = set(self.df['stmt_hash'].values)
         sd_hashes = set(ev_dict.keys())
         assert len(sd_hashes.intersection(df_hashes)) / len(sd_hashes) > 0.25

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -1,6 +1,5 @@
 __all__ = ['load_db_content', 'make_dataframe', 'make_ev_strata', 'NS_LIST']
 
-import sys
 import pickle
 import logging
 import argparse
@@ -14,7 +13,6 @@ except ImportError:
     pd = None
 
 from indra_db import util as dbu
-from indra.databases import hgnc_client, go_client, mesh_client
 
 logger = logging.getLogger(__name__)
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 NS_PRIORITY_LIST = (
     'FPLX',
+    'MIRBASE',
     'HGNC',
     'GO',
     'MESH',
@@ -31,7 +32,8 @@ NS_PRIORITY_LIST = (
 
 # All namespaces here (except NAME) should also be included in the
 # NS_PRIORITY_LIST above
-NS_LIST = ('NAME', 'HGNC', 'FPLX', 'GO', 'MESH', 'HMDB', 'CHEBI', 'PUBCHEM')
+NS_LIST = ('NAME', 'MIRBASE', 'HGNC', 'FPLX', 'GO', 'MESH', 'HMDB', 'CHEBI',
+           'PUBCHEM')
 
 
 def load_db_content(reload, ns_list, pkl_filename=None, db=None):

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -162,7 +162,7 @@ def make_dataframe(reconvert, db_content, pkl_filename=None):
                         ('agB_name', pair[1][2]),
                         ('stmt_type', info_dict['type']),
                         ('evidence_count', info_dict['ev_count']),
-                        ('hash', hash)])
+                        ('stmt_hash', hash)])
                 rows.append(row)
         if nkey_errors:
             ef = 'key_errors.csv'


### PR DESCRIPTION
This PR updates the sif dumper with the following:
- Add MIRBASE to NS list, and prioritize it higher than HGNC
- Rename: "hash" -> "stmt_hash" to conform with usage of IndraNet
- Use new resource file `source_mapping.json` that maps various source names in the DB to names used in the INDRA resource file `default_belief_probs.json`.