### PR TITLE
Add endpoints for the db API using the new query methods

### DIFF
--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -477,13 +477,14 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
             ag_dict = data['agents']
 
             num_agents = max(ag_dict.keys()) + 1  # Could be trailing Nones...
-            agent_key = str(tuple([ag_dict.get(n) for n in range(num_agents)]))
+            ordered_agents = [ag_dict.get(n) for n in range(num_agents)]
+            agent_key = '(' + ', '.join(ordered_agents) + ')'
 
             # Make the overall key
             if detail_level == 'relations':
                 key = data['type'] + agent_key
             else:
-                key = agent_key
+                key = 'Interaction' + agent_key
 
             # Handle new entries
             if key not in condensed:

--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -441,8 +441,8 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
     # Make a really fancy query to the database.
     mk_hashes_q, mk_hashes_al = _make_mk_hashes_query(db, agents, stmt_type)
 
-    _apply_limits(db, mk_hashes_q, best_first, max_relations, offset,
-                  mk_hashes_alias=mk_hashes_al)
+    mk_hashes_q = _apply_limits(db, mk_hashes_q, best_first, max_relations,
+                                offset, mk_hashes_alias=mk_hashes_al)
 
     mk_hashes_sq = mk_hashes_q.subquery('mk_hashes')
     names = (db.session.query(db.NameMeta.mk_hash, db.NameMeta.db_id,

--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -496,7 +496,7 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
             # Update existing entries.
             entry = condensed[key]
             if detail_level == 'agents':
-                entry['types'][data['type']] += sum(data['srcs'].valuse())
+                entry['types'][data['type']] += sum(data['srcs'].values())
 
             for src, cnt in data['srcs'].items():
                 entry['srcs'][src] += cnt

--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -510,7 +510,7 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
                 entry['types'] = dict(entry['types'])
             result.append(entry)
 
-    return result
+    return sorted(result, key=lambda data: data['tot'], reverse=True)
 
 
 def get_interaction_statements_from_agents(*args, **kwargs):

--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -457,7 +457,7 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
     for h, ag_name, ag_num, stmt_type, srcs in names:
         if h not in meta_dict.keys():
             meta_dict[h] = {'type': stmt_type, 'agents': {},
-                            'srcs': srcs.get_sources()}
+                            'source_counts': srcs.get_sources()}
         meta_dict[h]['agents'][ag_num] = ag_name
 
     # Condense the results, as indicated.
@@ -465,7 +465,7 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
     if detail_level == 'hashes':
         for h, data in meta_dict.items():
             data['hash'] = h
-            data['tot'] = sum(data['srcs'].values())
+            data['total_count'] = sum(data['source_counts'].values())
             result.append(data)
     else:
 
@@ -486,8 +486,9 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
 
             # Handle new entries
             if key not in condensed:
-                condensed[key] = {'hashes': {}, 'srcs': defaultdict(lambda: 0),
-                                  'tot': 0, 'agents': data['agents']}
+                condensed[key] = {'hashes': {},
+                                  'source_counts': defaultdict(lambda: 0),
+                                  'total_count': 0, 'agents': data['agents']}
                 if detail_level == 'relations':
                     condensed[key]['type'] = data['type']
                 else:
@@ -496,21 +497,21 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
             # Update existing entries.
             entry = condensed[key]
             if detail_level == 'agents':
-                entry['types'][data['type']] += sum(data['srcs'].values())
+                entry['types'][data['type']] += sum(data['source_counts'].values())
 
-            for src, cnt in data['srcs'].items():
-                entry['srcs'][src] += cnt
-                entry['tot'] += cnt
-            entry['hashes'][h] = sum(data['srcs'].values())
+            for src, cnt in data['source_counts'].items():
+                entry['source_counts'][src] += cnt
+                entry['total_count'] += cnt
+            entry['hashes'][h] = sum(data['source_counts'].values())
 
         # Convert defaultdict to normal dict and add to list.
         for entry in condensed.values():
-            entry['srcs'] = dict(entry['srcs'])
+            entry['source_counts'] = dict(entry['source_counts'])
             if detail_level == 'agents':
                 entry['types'] = dict(entry['types'])
             result.append(entry)
 
-    return sorted(result, key=lambda data: data['tot'], reverse=True)
+    return sorted(result, key=lambda data: data['total_count'], reverse=True)
 
 
 def get_interaction_statements_from_agents(*args, **kwargs):

--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -433,14 +433,17 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
 
     mk_hashes_sq = mk_hashes_q.subquery('mk_hashes')
     names = (db.session.query(db.NameMeta.mk_hash, db.NameMeta.db_id,
-                                db.NameMeta.ag_num, db.NameMeta.type)
-                       .filter(db.NameMeta.mk_hash == mk_hashes_sq.c.mk_hash)
+                              db.NameMeta.ag_num, db.NameMeta.type,
+                              db.PaStmtSrc)
+                       .filter(db.NameMeta.mk_hash == mk_hashes_sq.c.mk_hash,
+                               db.PaStmtSrc.mk_hash == mk_hashes_sq.c.mk_hash)
                        .all())
 
     meta_dict = {}
-    for h, ag_name, ag_num, stmt_type in names:
+    for h, ag_name, ag_num, stmt_type, srcs in names:
         if h not in meta_dict.keys():
-            meta_dict[h] = {'type': stmt_type, 'agents': {}}
+            meta_dict[h] = {'type': stmt_type, 'agents': {},
+                            'srcs': srcs.get_sources()}
         meta_dict[h]['agents'][ag_num] = ag_name
 
     return meta_dict

--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -471,9 +471,6 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
 
         # Re-aggregate the statements.
         condensed = {}
-        dense = defaultdict(lambda: {'hashes': {},
-                                     'srcs': defaultdict(lambda: 0),
-                                     'tot': 0})
         for h, data in meta_dict.items():
             # Make the agent key
             ag_dict = data['agents']
@@ -507,7 +504,7 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
             entry['hashes'][h] = data['srcs'].copy()
 
         # Convert defaultdict to normal dict and add to list.
-        for entry in dense.values():
+        for entry in condensed.values():
             entry['srcs'] = dict(entry['srcs'])
             result.append(entry)
 

--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -465,6 +465,7 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
     if detail_level == 'hashes':
         for h, data in meta_dict.items():
             data['hash'] = h
+            data['id'] = str(h)
             data['total_count'] = sum(data['source_counts'].values())
             result.append(data)
     else:
@@ -476,17 +477,17 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
             ag_dict = data['agents']
 
             num_agents = max(ag_dict.keys()) + 1  # Could be trailing Nones...
-            agent_key = tuple([ag_dict.get(n) for n in range(num_agents)])
+            agent_key = str(tuple([ag_dict.get(n) for n in range(num_agents)]))
 
             # Make the overall key
             if detail_level == 'relations':
-                key = (data['type'], agent_key)
+                key = data['type'] + agent_key
             else:
                 key = agent_key
 
             # Handle new entries
             if key not in condensed:
-                condensed[key] = {'hashes': {},
+                condensed[key] = {'hashes': {}, 'id': key,
                                   'source_counts': defaultdict(lambda: 0),
                                   'total_count': 0, 'agents': data['agents']}
                 if detail_level == 'relations':

--- a/indra_db/client/optimized.py
+++ b/indra_db/client/optimized.py
@@ -421,18 +421,18 @@ def get_statement_jsons_from_agents(agents=None, stmt_type=None, db=None,
 @clockit
 def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
                                       best_first=True, max_relations=None,
-                                      offset=None, detail_level='hash'):
+                                      offset=None, detail_level='hashes'):
     """Get simple reaction information available from Statement metadata.
 
     There are three levels of detail:
-        hash -> Each entry in the result corresponds to a single preassembled
+        hashes -> Each entry in the result corresponds to a single preassembled
                 statement, distinguished by its hash.
         relations -> Each entry in the result corresponds to a relation, meaning
                 an interaction type, and the names of the agents involved.
         agents -> Each entry is simply a pair (or more) of Agents involved in
                 an interaction.
     """
-    if detail_level not in {'hash', 'relations', 'agents'}:
+    if detail_level not in {'hashes', 'relations', 'agents'}:
         raise ValueError("Invalid detail_level: %s" % detail_level)
 
     if db is None:
@@ -462,7 +462,7 @@ def get_interaction_jsons_from_agents(agents=None, stmt_type=None, db=None,
 
     # Condense the results, as indicated.
     result = []
-    if detail_level == 'hash':
+    if detail_level == 'hashes':
         for h, data in meta_dict.items():
             data['hash'] = h
             data['tot'] = sum(data['srcs'].values())

--- a/indra_db/managers/database_manager.py
+++ b/indra_db/managers/database_manager.py
@@ -878,6 +878,14 @@ class DatabaseManager(object):
                 cls.loaded = True
                 return
 
+            def get_sources(self, include_none=False):
+                src_dict = {}
+                for k, v in self.__dict__.items():
+                    if k not in {'mk_hash'} and not k.startswith('_'):
+                        if include_none or v is not None:
+                            src_dict[k] = v
+                return src_dict
+
             mk_hash = Column(BigInteger, primary_key=True)
         self.__PaStmtSrc = PaStmtSrc
         self.m_views[PaStmtSrc.__tablename__] = PaStmtSrc

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -506,7 +506,8 @@ def get_metadata(level):
                                             offset=pop('offset'),
                                             best_first=pop('best_first', True))
 
-    logger.info("Got %s results." % len(res))
+    dt = (datetime.utcnow() - start).total_seconds()
+    logger.info("Got %s results after %.2f." % (len(res), dt))
 
     # Currently, a has could get through (in one of the less detailed results)
     # that is entirely dependent on medscan.
@@ -519,12 +520,16 @@ def get_metadata(level):
         res = censored_res
 
     dt = (datetime.utcnow() - start).total_seconds()
-    logger.info("Returning with %s results after %s seconds."
+    logger.info("Returning with %s results after %.2f seconds."
                 % (len(res), dt))
 
-    return Response(json.dumps(sorted(res, key=lambda e: e['tot'],
+    resp = Response(json.dumps(sorted(res, key=lambda e: e['tot'],
                                       reverse=True)),
                     mimetype='application/json')
+
+    dt = (datetime.utcnow() - start).total_seconds()
+    logger.info("Result prepared after %.2f seconds." % dt)
+    return resp
 
 
 if __name__ == '__main__':

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -500,8 +500,10 @@ def get_metadata(level):
             return query.pop(k, str(default).lower()) == 'true'
         return query.pop(k, default)
 
+    stmt_type = pop('type')
+    stmt_type = None if stmt_type is None else make_statement_camel(stmt_type)
     res = get_interaction_jsons_from_agents(agents=agents, detail_level=level,
-                                            stmt_type=pop('type'),
+                                            stmt_type=stmt_type,
                                             max_relations=pop('limit'),
                                             offset=pop('offset'),
                                             best_first=pop('best_first', True))

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -511,13 +511,13 @@ def get_metadata(level):
     dt = (datetime.utcnow() - start).total_seconds()
     logger.info("Got %s results after %.2f." % (len(res), dt))
 
-    # Currently, a has could get through (in one of the less detailed results)
+    # Currently, a hash could get through (in one of the less detailed results)
     # that is entirely dependent on medscan.
     if not has['medscan']:
         censored_res = []
         for entry in res:
-            entry['tot'] -= entry['srcs'].pop('medscan', 0)
-            if entry['srcs']:
+            entry['total_count'] -= entry['source_counts'].pop('medscan', 0)
+            if entry['source_counts']:
                 censored_res.append(entry)
         res = censored_res
 
@@ -525,7 +525,7 @@ def get_metadata(level):
     logger.info("Returning with %s results after %.2f seconds."
                 % (len(res), dt))
 
-    resp = Response(json.dumps(sorted(res, key=lambda e: e['tot'],
+    resp = Response(json.dumps(sorted(res, key=lambda e: e['total_count'],
                                       reverse=True)),
                     mimetype='application/json')
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -494,15 +494,16 @@ def get_metadata(level):
         abort(Response('Failed to make agents from names: %s\n' % str(e), 400))
         return
 
-    def pop_bool(k, default=None):
+    def pop(k, default=None):
         if isinstance(default, bool):
             return query.pop(k, str(default).lower()) == 'true'
         return query.pop(k, default)
 
     res = get_interaction_jsons_from_agents(agents=agents, detail_level=level,
-                                            max_relations=pop_bool('limit'),
-                                            offset=pop_bool('offset'),
-                                            best_first=pop_bool('best_first', True))
+                                            stmt_type=pop('type'),
+                                            max_relations=pop('limit'),
+                                            offset=pop('offset'),
+                                            best_first=pop('best_first', True))
 
     logger.info("Got %s results." % len(res))
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -467,6 +467,7 @@ def submit_curation_endpoint(hash_val, **kwargs):
 @app.route('/metadata/<level>/from_agents', methods=['GET'])
 @jwt_optional
 def get_metadata(level):
+    start = datetime.utcnow()
     query = request.args.copy()
 
     # Figure out authorization.
@@ -517,7 +518,9 @@ def get_metadata(level):
                 censored_res.append(entry)
         res = censored_res
 
-    logger.info("Returning with %s results." % len(res))
+    dt = (datetime.utcnow() - start).total_seconds()
+    logger.info("Returning with %s results after %s seconds."
+                % (len(res), dt))
 
     return jsonify(list(sorted(res, key=lambda e: e['tot'], reverse=True)))
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -522,7 +522,9 @@ def get_metadata(level):
     logger.info("Returning with %s results after %s seconds."
                 % (len(res), dt))
 
-    return jsonify(list(sorted(res, key=lambda e: e['tot'], reverse=True)))
+    return Response(json.dumps(sorted(res, key=lambda e: e['tot'],
+                                      reverse=True)),
+                    mimetype='application/json')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This incorporates a simpler and faster method for querying statement information without needing to access the statement JSONs themselves. This PR also includes some revision of the client query itself to support different aggregation strategies. 