### PR TITLE
Fix method getting full name

### DIFF
--- a/indra_db/schemas/mixins.py
+++ b/indra_db/schemas/mixins.py
@@ -35,11 +35,24 @@ class IndraDBTable(object):
         """Get the full name including the schema, if supplied."""
         name = cls.__tablename__
 
-        schema_name = cls.__table_args__.get('schema')
+        # If we are definitely going to include the schema, default to public
+        if force_schema:
+            schema_name = 'public'
+        else:
+            schema_name = None
+
+        # Look for any information in the __table_args__ about the schema
+        if isinstance(cls.__table_args__, dict):
+            schema_name = cls.__table_args__.get('schema')
+        elif isinstance(cls.__table_args__, tuple):
+            for arg in cls.__table_args__:
+                if isinstance(arg, dict) and 'schema' in arg.keys():
+                    schema_name = arg['schema']
+                    break
+
+        # Prepend if we found something.
         if schema_name:
             name = schema_name + '.' + name
-        elif force_schema:
-            name = 'public' + '.' + name
 
         return name
 

--- a/indra_db/tests/test_client.py
+++ b/indra_db/tests/test_client.py
@@ -385,3 +385,16 @@ def test_source_hash():
         assert sh_rec == sh,\
             "Recreated source hash %s does not match database sourch hash %s."\
             % (sh_rec, sh)
+
+
+def test_get_raw_statement_jsons_from_agents():
+    db = get_prepped_db(100000)
+    res = dbc.get_direct_raw_stmt_jsons_from_agents(db=db, agents=[
+        ('SUBJECT', 'MEK', 'FPLX'),
+    ])
+    assert len(res)
+    assert isinstance(res, dict)
+    stmts = stmts_from_json(res.values())
+    assert stmts
+    assert all('MEK' == s.agent_list()[0].db_refs['FPLX']
+               for s in stmts), stmts

--- a/indra_db/tests/test_client.py
+++ b/indra_db/tests/test_client.py
@@ -405,7 +405,7 @@ def test_get_raw_statement_json_from_papers():
     pmid, = db.select_one(db.TextRef.pmid, db.TextRef.pmid.isnot(None),
                           *db.link(db.TextRef, db.RawStatements))
 
-    res = dbc.get_raw_stmt_jsons_from_papers([pmid], id_type='pmid')
+    res = dbc.get_raw_stmt_jsons_from_papers([pmid], id_type='pmid', db=db)
     assert len(res) == 1, len(res)
     assert pmid in res.keys(), 'Expected %s in %s' % (pmid, res.keys())
     stmts = stmts_from_json(res[pmid])

--- a/indra_db/tests/test_client.py
+++ b/indra_db/tests/test_client.py
@@ -398,3 +398,15 @@ def test_get_raw_statement_jsons_from_agents():
     assert stmts
     assert all('MEK' == s.agent_list()[0].db_refs['FPLX']
                for s in stmts), stmts
+
+
+def test_get_raw_statement_json_from_papers():
+    db = get_prepped_db(10000)
+    pmid, = db.select_one(db.TextRef.pmid, db.TextRef.pmid.isnot(None),
+                          *db.link(db.TextRef, db.RawStatements))
+
+    res = dbc.get_raw_stmt_jsons_from_papers([pmid], id_type='pmid')
+    assert len(res) == 1, len(res)
+    assert pmid in res.keys(), 'Expected %s in %s' % (pmid, res.keys())
+    stmts = stmts_from_json(res[pmid])
+    assert len(stmts)


### PR DESCRIPTION
It turns out `__table_args__` can be either tuples or dicts, so I needed to adapt the code to handle that scenario. I also added tests of the functions that were failing so such issues don't go unnoticed in future.