### PR TITLE
Update loading BEL corpora

### DIFF
--- a/indra_db/managers/knowledgebase_manager.py
+++ b/indra_db/managers/knowledgebase_manager.py
@@ -244,7 +244,10 @@ class BelLcManager(KnowledgebaseManager):
         from indra.sources import bel
 
         pbp = bel.process_large_corpus()
-        stmts, dups = extract_duplicates(pbp.statements,
+        stmts = pbp.statements
+        pbp = bel.process_small_corpus()
+        stmts += pbp.statements
+        stmts, dups = extract_duplicates(stmts,
                                          key_func=KeyFunc.mk_and_one_ev_src)
         print('\n'.join(str(dup) for dup in dups))
         print(len(stmts), len(dups))


### PR DESCRIPTION
This PR processes the latest BEL large corpus from its maintained repository via a new INDRA API call. It also adds the BEL small corpus which is a small but distinct set of BEL Statements from the same source. One question is whether `bel_lc` is still adequate given that it's not just the large corpus being added, `bel_selventa` would be a more fitting source name though this would have to propagate into several places so this PR doesn't make any change yet.