### PR TITLE
Implement Readonly Updating

### DIFF
--- a/indra_db/client/readonly/pa_statements.py
+++ b/indra_db/client/readonly/pa_statements.py
@@ -194,7 +194,7 @@ def _get_pa_stmt_jsons_w_mkhash_subquery(ro, mk_hashes_q, best_first=True,
     if censured_sources is not None:
         cont_q = cont_q.filter(ro.RawStmtSrc.sid == ro.FastRawPaLink.id)
         for src in censured_sources:
-            cont_q = cont_q.filter(ro.RawStmtSrc.src.notlike(src))
+            cont_q = cont_q.filter(ro.RawStmtSrc.src.is_distinct_from(src))
 
     if ev_limit is not None:
         cont_q = cont_q.limit(ev_limit)

--- a/indra_db/client/tools.py
+++ b/indra_db/client/tools.py
@@ -30,7 +30,7 @@ def _apply_limits(db, mk_hashes_q, best_first, max_stmts, offset,
 
         for src in censured_sources:
             mk_hashes_q = (mk_hashes_q
-                           .filter(db.PaSourceLookup.only_src.notlike(src)))
+                     .filter(db.PaSourceLookup.only_src.is_distinct_from(src)))
     if max_stmts is not None:
         mk_hashes_q = mk_hashes_q.limit(max_stmts)
     if offset is not None:

--- a/indra_db/config.py
+++ b/indra_db/config.py
@@ -63,8 +63,8 @@ def _load_config():
                     for k in parser.options(section)}
 
         # Handle the case for the s3 bucket spec.
-        if section == 'aws-s3':
-            CONFIG['s3_dump'] = def_dict
+        if section.starswith('aws-'):
+            CONFIG[section[4:]] = def_dict
             continue
 
         # Extract all the database connection data

--- a/indra_db/config.py
+++ b/indra_db/config.py
@@ -17,6 +17,7 @@ DB_STR_FMT = "{prefix}://{username}{password}{host}{port}/{name}"
 PRINCIPAL_ENV_PREFIX = 'INDRADB'
 READONLY_ENV_PREFIX = 'INDRARO'
 S3_DUMP_ENV_VAR = 'INDRA_DB_S3_PREFIX'
+LAMBDA_NAME_ENV_VAR = 'DB_SERVICE_LAMBDA_NAME'
 
 
 logger = logging.getLogger('db_config')
@@ -100,6 +101,10 @@ def _load_env_config():
     if S3_DUMP_ENV_VAR in environ:
         bucket, prefix = environ[S3_DUMP_ENV_VAR].split(':')
         CONFIG['s3_dump'] = {'bucket': bucket, 'prefix': prefix}
+
+    if LAMBDA_NAME_ENV_VAR in environ:
+        role, function = environ[LAMBDA_NAME_ENV_VAR].split(':')
+        CONFIG['lambda'] = {'role': role, 'function': function}
 
     return
 

--- a/indra_db/config.py
+++ b/indra_db/config.py
@@ -63,7 +63,7 @@ def _load_config():
                     for k in parser.options(section)}
 
         # Handle the case for the s3 bucket spec.
-        if section.starswith('aws-'):
+        if section.startswith('aws-'):
             CONFIG[section[4:]] = def_dict
             continue
 
@@ -132,3 +132,6 @@ def get_s3_dump(force_update=False, include_config=True):
         _load(include_config)
 
     return CONFIG['s3_dump']
+
+
+_load(True)

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -991,7 +991,6 @@ class ReadonlyDatabaseManager(DatabaseManager):
             if force_clear:
                 # For some reason, dropping tables does not work.
                 self.drop_schema('readonly')
-                self.create_schema('readonly')
             else:
                 raise IndraDbException("Tables already exist and force_clear "
                                        "is False.")

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -893,12 +893,6 @@ class PrincipalDatabaseManager(DatabaseManager):
                         '|', 'aws', 's3', 'cp', '-', dump_file])
         check_call(cmd, shell=True, env=my_env)
 
-        # This database no longer needs this schema (this only executes if
-        # the check_call does not error).
-        self.session.close()
-        self.grab_session()
-        self.drop_schema('readonly')
-
         return dump_file
 
 

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -1,3 +1,5 @@
+from subprocess import STDOUT
+
 __all__ = ['texttypes', 'formats', 'DatabaseManager', 'IndraDbException',
            'sql_expressions', 'readers', 'reader_versions',
            'PrincipalDatabaseManager', 'ReadonlyDatabaseManager']
@@ -330,6 +332,7 @@ class DatabaseManager(object):
     def drop_schema(self, schema_name, cascade=True):
         """Drop a schema (rather forcefully by default)"""
         with self.engine.connect() as con:
+            logger.info("Dropping schema %s." % schema_name)
             con.execute('DROP SCHEMA IF EXISTS %s %s;'
                         % (schema_name, 'CASCADE' if cascade else ''))
         return
@@ -999,7 +1002,7 @@ class ReadonlyDatabaseManager(DatabaseManager):
         check_call(' '.join(['aws', 's3', 'cp', dump_file, '-', '|',
                              'pg_restore', *self._form_pg_args(),
                              '--no-owner']),
-                   env=my_env, shell=True)
+                   env=my_env, shell=True, stdout=STDOUT)
 
         self.session.close()
         self.grab_session()

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -1,5 +1,3 @@
-from subprocess import STDOUT
-
 __all__ = ['texttypes', 'formats', 'DatabaseManager', 'IndraDbException',
            'sql_expressions', 'readers', 'reader_versions',
            'PrincipalDatabaseManager', 'ReadonlyDatabaseManager']
@@ -979,7 +977,7 @@ class ReadonlyDatabaseManager(DatabaseManager):
 
     def load_dump(self, dump_file, force_clear=True):
         """Load from a dump of the readonly schema on s3."""
-        from subprocess import check_call
+        from subprocess import run
         from os import environ
 
         self.session.close()
@@ -999,10 +997,9 @@ class ReadonlyDatabaseManager(DatabaseManager):
                                        "is False.")
 
         # Pipe the database dump from s3 through this machine into the database
-        check_call(' '.join(['aws', 's3', 'cp', dump_file, '-', '|',
-                             'pg_restore', *self._form_pg_args(),
-                             '--no-owner']),
-                   env=my_env, shell=True, stdout=STDOUT)
+        run(' '.join(['aws', 's3', 'cp', dump_file, '-', '|',
+                      'pg_restore', *self._form_pg_args(), '--no-owner']),
+            env=my_env, shell=True, check=True)
 
         self.session.close()
         self.grab_session()

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -9,6 +9,8 @@ from io import BytesIO
 from numbers import Number
 from datetime import datetime
 
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
 from sqlalchemy.sql import expression as sql_expressions
 from sqlalchemy.schema import DropTable
 from sqlalchemy.sql.expression import Delete, Update
@@ -806,9 +808,9 @@ class DatabaseManager(object):
 
     def vacuum(self, analyze=True):
         conn = self.engine.raw_connection()
+        conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         cursor = conn.cursor()
-        cursor.execute('vacuum' + (' analyze;' if analyze else ''))
-        conn.commit()
+        cursor.execute('VACUUM' + (' ANALYZE;' if analyze else ''))
         return
 
 

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -804,10 +804,10 @@ class DatabaseManager(object):
                 '-w',  # Don't prompt for a password, forces use of env.
                 '-d', self.url.database]
 
-    def vacuum(self):
+    def vacuum(self, analyze=True):
         conn = self.engine.raw_connection()
         cursor = conn.cursor()
-        cursor.execute('vacuum')
+        cursor.execute('vacuum' + (' analyze;' if analyze else ''))
         conn.commit()
         return
 

--- a/indra_db/managers/readonly_manager.py
+++ b/indra_db/managers/readonly_manager.py
@@ -68,7 +68,10 @@ def main():
 
     logger.info("%s - Generating readonly schema (est. a long time)"
                 % datetime.now())
-    principal_db.generate_readonly(ro_list=ro_names)
+    if args.delete_existing and 'readonly' in principal_db.get_schemas():
+        principal_db.drop_schema('readonly')
+    principal_db.generate_readonly(ro_list=ro_names,
+                                   allow_continue=args.allow_continue)
 
     logger.info("%s - Beginning dump of database (est. 1 + epsilon hours)"
                 % datetime.now())
@@ -111,6 +114,21 @@ def parse_args():
         default='all',
         nargs='+',
         help='Specify certain views to create or refresh.'
+    )
+    parser.add_argument(
+        '-a', '--allow_continue',
+        default=False,
+        type=bool,
+        help=("Indicate whether you want to job to continue building atop an "
+              "existing readonly schema, or if you want it to give up if the "
+              "schema already exists.")
+    )
+    parser.add_argument(
+        '-d', '--delete_existing',
+        default=False,
+        type=bool,
+        help=("Add this flag to delete an existing schema if it exists. "
+              "Selecting this option makes -a/--allow_continue moot.")
     )
 
     args = parser.parse_args()

--- a/indra_db/managers/readonly_manager.py
+++ b/indra_db/managers/readonly_manager.py
@@ -90,6 +90,7 @@ def main():
     # Load the database into the readonly database
     if not args.dump_only:
         readonly_db = get_ro(args.readonly)
+        logger.info("Using dump_file = \"%s\"." % dump_file)
         logger.info("%s - Beginning upload of content (est. ~30 minutes)"
                     % datetime.now())
         with ReadonlyTransferEnv(principal_db, readonly_db):

--- a/indra_db/managers/readonly_manager.py
+++ b/indra_db/managers/readonly_manager.py
@@ -44,7 +44,7 @@ class ReadonlyTransferEnv(object):
 
     def _set_lambda_env(self, env_dict):
         lambda_client = get_lambda_client()
-        lambda_client.update_function_configureation(
+        lambda_client.update_function_configuration(
             FunctionName=aws_lambda_function,
             Environment={"Variables": env_dict}
         )

--- a/indra_db/managers/readonly_manager.py
+++ b/indra_db/managers/readonly_manager.py
@@ -78,6 +78,12 @@ def main():
                 % datetime.now())
     with ReadonlyTransferEnv(principal_db, readonly_db):
         readonly_db.load_dump(dump_file)
+
+    # This database no longer needs this schema (this only executes if
+    # the check_call does not error).
+    principal_db.session.close()
+    principal_db.grab_session()
+    principal_db.drop_schema('readonly')
     return
 
 

--- a/indra_db/managers/readonly_manager.py
+++ b/indra_db/managers/readonly_manager.py
@@ -117,16 +117,14 @@ def parse_args():
     )
     parser.add_argument(
         '-a', '--allow_continue',
-        default=False,
-        type=bool,
+        action='store_true',
         help=("Indicate whether you want to job to continue building atop an "
               "existing readonly schema, or if you want it to give up if the "
               "schema already exists.")
     )
     parser.add_argument(
         '-d', '--delete_existing',
-        default=False,
-        type=bool,
+        action='store_true',
         help=("Add this flag to delete an existing schema if it exists. "
               "Selecting this option makes -a/--allow_continue moot.")
     )

--- a/indra_db/managers/readonly_manager.py
+++ b/indra_db/managers/readonly_manager.py
@@ -52,8 +52,15 @@ class ReadonlyTransferEnv(object):
     def __enter__(self):
         self._set_lambda_env({'INDRAROOVERRIDE': str(self.principal.url)})
 
-    def __exit__(self):
-        self._set_lambda_env({})
+    def __exit__(self, exc_type, value, traceback):
+        # Check for exceptions. Only change back over if there were no
+        # exceptions.
+        if exc_type is None:
+            self._set_lambda_env({})
+        else:
+            logger.warning("An error %s occurred. Assuming the database is "
+                           "not usable, and not transfering the service back "
+                           "to Readonly." % exc_type)
 
 
 def main():

--- a/indra_db/managers/readonly_manager.py
+++ b/indra_db/managers/readonly_manager.py
@@ -50,12 +50,15 @@ class ReadonlyTransferEnv(object):
         )
 
     def __enter__(self):
+        logger.info("Redirecting the service to %s." % self.principal.url)
         self._set_lambda_env({'INDRAROOVERRIDE': str(self.principal.url)})
 
     def __exit__(self, exc_type, value, traceback):
         # Check for exceptions. Only change back over if there were no
         # exceptions.
         if exc_type is None:
+            logger.info("Directing the service back to %s."
+                        % self.readonly.url)
             self._set_lambda_env({})
         else:
             logger.warning("An error %s occurred. Assuming the database is "

--- a/indra_db/managers/readonly_manager.py
+++ b/indra_db/managers/readonly_manager.py
@@ -30,8 +30,8 @@ def get_lambda_client():
         new_role_arn = "arn:aws:iam::%s:role/%s" % (ident['Account'], aws_role)
         res = sts.assume_role(RoleArn=new_role_arn,
                               RoleSessionName="AssumeRoleReadonlyDBUpdate")
-        kwargs = {uncamel(k): v for k, v in res['Credentials'].items()
-                  if 'expiration' not in k}
+        kwargs = {'aws_' + uncamel(k): v for k, v in res['Credentials'].items()
+                  if 'expiration' not in k.lower()}
 
     # Get a client to Lambda
     return boto3.client('lambda', **kwargs)

--- a/indra_db/resources/default_db_config.ini
+++ b/indra_db/resources/default_db_config.ini
@@ -42,6 +42,13 @@ name = indradb_readonly_test
 
 # AWS S3 dump site:
 # -----------------
-[aws-s3]
+[aws-s3_dump]
 bucket =
 prefix =
+
+
+# AWS Lambda Config:
+# ------------------
+[aws-lambda]
+role =
+function =

--- a/indra_db/schemas/mixins.py
+++ b/indra_db/schemas/mixins.py
@@ -21,9 +21,8 @@ class IndraDBTable(object):
         if commit:
             try:
                 cls.execute(db, sql)
-            except DuplicateTable as err:
-                logger.warning("Got error (%s) when building %s. Skipping."
-                               % (err, index.name))
+            except DuplicateTable:
+                logger.info("%s exists, skipping." % index.name)
         return sql
 
     @classmethod

--- a/indra_db/schemas/mixins.py
+++ b/indra_db/schemas/mixins.py
@@ -29,7 +29,7 @@ class IndraDBTable(object):
     @classmethod
     def build_indices(cls, db):
         for index in cls._indices:
-            print("Building index: %s" % index.name)
+            logger.info("Building index: %s" % index.name)
             cls.create_index(db, index)
 
     @staticmethod

--- a/indra_db/schemas/readonly_schema.py
+++ b/indra_db/schemas/readonly_schema.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 CREATE_ORDER = ['raw_stmt_src', 'fast_raw_pa_link', 'pa_stmt_src',
                 'evidence_counts', 'pa_source_lookup', 'pa_ref_link',
-                'pa_meta', 'text_meta', 'name_meta']
+                'pa_meta', 'text_meta', 'name_meta', 'other_meta']
 CREATE_UNORDERED = {'reading_ref_link'}
 
 
@@ -38,6 +38,7 @@ def get_schema(Base):
       7. pa_meta
       8. text_meta
       9. name_meta
+     10. other_meta
     The following can be built at any time and in any order:
       - reading_ref_link
     Note that the order of views below is determined not by the above

--- a/indra_db/schemas/readonly_schema.py
+++ b/indra_db/schemas/readonly_schema.py
@@ -264,7 +264,7 @@ def get_schema(Base):
             return src_dict
     read_views[PaStmtSrc.__tablename__] = PaStmtSrc
 
-    class PaRefLink(Base, SpecialColumnTable):
+    class PaRefLink(Base, ReadonlyTable):
         __tablename__ = 'pa_ref_link'
         __table_args__ = {'schema': 'readonly'}
         __definition__ = ('SELECT mk_hash, trid, pmid, pmcid, source, reader '

--- a/indra_db/schemas/readonly_schema.py
+++ b/indra_db/schemas/readonly_schema.py
@@ -13,9 +13,10 @@ from .indexes import *
 logger = logging.getLogger(__name__)
 
 CREATE_ORDER = ['raw_stmt_src', 'fast_raw_pa_link', 'pa_stmt_src',
-                'evidence_counts', 'pa_source_lookup', 'pa_ref_link',
-                'pa_meta', 'text_meta', 'name_meta', 'other_meta']
-CREATE_UNORDERED = {'reading_ref_link'}
+                'evidence_counts', 'pa_source_lookup', 'reading_ref_link',
+                'pa_ref_link', 'pa_meta', 'text_meta', 'name_meta',
+                'other_meta']
+CREATE_UNORDERED = {}
 
 
 def get_schema(Base):
@@ -34,13 +35,14 @@ def get_schema(Base):
       3. pa_stmt_src
       4. evidence_counts
       5. pa_source_lookup
-      6. pa_ref_link
-      7. pa_meta
-      8. text_meta
-      9. name_meta
-     10. other_meta
+      6. reading_ref_link
+      7. pa_ref_link
+      8. pa_meta
+      9. text_meta
+     10. name_meta
+     11. other_meta
     The following can be built at any time and in any order:
-      - reading_ref_link
+        (None currently)
     Note that the order of views below is determined not by the above
     order but by constraints imposed by use-case.
     '''

--- a/indra_db/schemas/readonly_schema.py
+++ b/indra_db/schemas/readonly_schema.py
@@ -30,8 +30,8 @@ def get_schema(Base):
 
     The following views must be built in this specific order:
       1. raw_stmt_src
-      2. pa_stmt_src
-      3. fast_raw_pa_link
+      2. fast_raw_pa_link
+      3. pa_stmt_src
       4. evidence_counts
       5. pa_source_lookup
       6. pa_meta
@@ -96,7 +96,8 @@ def get_schema(Base):
                           'raw_unique_links AS link,'
                           'readonly.raw_stmt_src as raw_src '
                           'WHERE link.raw_stmt_id = raw.id '
-                          'AND link.pa_stmt_mk_hash = pa.mk_hash')
+                          'AND link.pa_stmt_mk_hash = pa.mk_hash '
+                          'AND raw_src.sid = raw.id')
         _skip_disp = ['raw_json', 'pa_json']
         _indices = [BtreeIndex('hash_index', 'mk_hash'),
                     BtreeIndex('frp_reading_id_idx', 'reading_id'),
@@ -219,9 +220,8 @@ def get_schema(Base):
         __tablename__ = 'pa_stmt_src'
         __table_args__ = {'schema': 'readonly'}
         __definition_fmt__ = ("SELECT * FROM crosstab("
-                              "'SELECT mk_hash, src, count(sid) "
-                              "  FROM readonly.raw_stmt_src "
-                              "   JOIN readonly.fast_raw_pa_link ON sid = id "
+                              "'SELECT mk_hash, src, count(id) "
+                              "  FROM readonly.fast_raw_pa_link "
                               "  GROUP BY (mk_hash, src)', "
                               "$$SELECT unnest('{%s}'::text[])$$"
                               " ) final_result(mk_hash bigint, %s)")

--- a/indra_db/schemas/readonly_schema.py
+++ b/indra_db/schemas/readonly_schema.py
@@ -12,7 +12,7 @@ from .indexes import *
 
 logger = logging.getLogger(__name__)
 
-CREATE_ORDER = ['raw_stmt_src', 'pa_stmt_src', 'fast_raw_pa_link',
+CREATE_ORDER = ['raw_stmt_src', 'fast_raw_pa_link', 'pa_stmt_src',
                 'evidence_counts', 'pa_source_lookup', 'pa_meta', 'text_meta',
                 'name_meta']
 CREATE_UNORDERED = {'reading_ref_link'}

--- a/indra_db/util/constructors.py
+++ b/indra_db/util/constructors.py
@@ -78,6 +78,9 @@ def get_db(db_label):
 def get_ro(ro_label):
     """Get a readonly database instance, based on its name/"""
     defaults = get_readonly_databases()
+    if ro_label == 'primary' and 'override' in defaults:
+        logger.info("Found an override database: using in place of primary.")
+        ro_label = 'override'
     db_url = defaults[ro_label]
     ro = ReadonlyDatabaseManager(db_url, label=ro_label)
     ro.grab_session()


### PR DESCRIPTION
Develop the code needed to seamlessly update the readonly database. The key change is that the lambda service(s) can now have the readonly database that they point to overridden via an environment variable. This allows the service to read from the principal database's copy of the readonly schema while the schema is being push to the readonly database.