### PR TITLE
Skip raw statements only once

### DIFF
--- a/indra_db/managers/preassembly_manager.py
+++ b/indra_db/managers/preassembly_manager.py
@@ -201,6 +201,8 @@ class PreassemblyManager(object):
             # Make sure the discarded statements table is cleared.
             db.drop_tables([db.DiscardedStatements])
             db.create_tables([db.DiscardedStatements])
+            db.session.close()
+            db.grab_session()
 
         # Get filtered statement ID's.
         sid_cache_fname = path.join(HERE, 'stmt_id_cache.pkl')

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -211,8 +211,9 @@ def get_schema(Base):
         __tablename__ = 'discarded_statements'
         _always_disp = ['stmt_id', 'reason']
         id = Column(Integer, primary_key=True)
-        stmt_id = Column(Integer)
-        reason = Column(String)
+        stmt_id = Column(Integer, ForeignKey('raw_statements.id'),
+                         nullable=False)
+        reason = Column(String, nullable=False)
         insert_date = Column(DateTime, default=func.now())
     table_dict[DiscardedStatements.__tablename__] = DiscardedStatements
 

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -207,6 +207,15 @@ def get_schema(Base):
         create_date = Column(DateTime, default=func.now())
     table_dict[RejectedStatements.__tablename__] = RejectedStatements
 
+    class DiscardedStatements(Base, IndraDBTable):
+        __tablename__ = 'discarded_statements'
+        _always_disp = ['stmt_id', 'reason']
+        id = Column(Integer, primary_key=True)
+        stmt_id = Column(Integer)
+        reason = Column(String)
+        insert_date = Column(DateTime, default=func.now())
+    table_dict[DiscardedStatements.__tablename__] = DiscardedStatements
+
     class RawAgents(Base, IndraDBTable):
         __tablename__ = 'raw_agents'
         _always_disp = ['stmt_id', 'db_name', 'db_id', 'ag_num']

--- a/indra_db/tests/util.py
+++ b/indra_db/tests/util.py
@@ -296,6 +296,8 @@ def get_pa_loaded_db(num_stmts, split=None, pam=None):
     else:
         dts.add_statements(split, pam=pam)
         dts.add_statements()
+    dts.test_db.session.close()
+    dts.test_db.grab_session()
     return dts.test_db
 
 


### PR DESCRIPTION
Record which raw statements were skipped in a new table, discarded_statements, and skip those statements in the future to avoid re-hashing the same statements over and over again.