### PR TITLE
Integrate curations into new interface

### DIFF
--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -382,7 +382,7 @@ def get_schema(Base):
         def to_json(self):
             return {attr: getattr(self, attr)
                     for attr in ['id', 'pa_hash', 'source_hash', 'tag', 'text',
-                                 'date']}
+                                 'date', 'curator', 'source']}
 
     table_dict[Curation.__tablename__] = Curation
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -83,6 +83,7 @@ def _query_wrapper(f):
                         MAX_STATEMENTS)
         fmt = query.pop('format', 'json')
         w_english = query.pop('with_english', 'false').lower() == 'true'
+        w_cur_counts = query.pop('with_cur_counts', 'false').lower() == 'true'
 
         # Figure out authorization.
         has = dict.fromkeys(['elsevier', 'medscan'], False)
@@ -142,6 +143,17 @@ def _query_wrapper(f):
 
         logger.info("Finished redacting evidence for %s after %s seconds."
                     % (f.__name__, sec_since(start_time)))
+
+        # Get counts of the curations for the resulting statements.
+        if w_cur_counts:
+            curations = get_curations(pa_hash=set(stmts_json.keys()))
+            logger.info("Found %d curations" % len(curations))
+            cur_counts = {}
+            for curation in curations:
+                if curation.pa_hash not in cur_counts:
+                    cur_counts[curation.pa_hash] = 0
+                cur_counts[curation.pa_hash] += 1
+            result['num_curations'] = cur_counts
 
         # Add derived values to the result.
         result['offset'] = offs

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -12,7 +12,8 @@ from flask_jwt_extended import get_jwt_identity, jwt_optional
 from jinja2 import Environment, ChoiceLoader
 
 from indra.assemblers.html.assembler import loader as indra_loader, \
-    stmts_from_json, HtmlAssembler, SOURCE_COLORS
+    stmts_from_json, HtmlAssembler, SOURCE_COLORS, _format_evidence_text, \
+    _format_stmt_text
 from indra.assemblers.english import EnglishAssembler
 from indra.statements import make_statement_camel
 
@@ -114,13 +115,14 @@ def _query_wrapper(f):
         if not all(has.values()) or fmt == 'json-js' or w_english:
             for h, stmt_json in stmts_json.copy().items():
                 if w_english:
-                    stmts = stmts_from_json([stmt_json])
-                    stmt_json['english'] = EnglishAssembler(stmts).make_model()
+                    stmt = stmts_from_json([stmt_json])[0]
+                    stmt_json['english'] = _format_stmt_text(stmt)
+                    stmt_json['evidence'] = _format_evidence_text(stmt)
 
                 if not has['medscan']:
                     source_counts[h].pop('medscan', None)
 
-                if has['elsevier'] and fmt != 'json-js':
+                if has['elsevier'] and fmt != 'json-js' and not w_english:
                     continue
 
                 for ev_json in stmt_json['evidence'][:]:

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -150,9 +150,17 @@ def _query_wrapper(f):
             logger.info("Found %d curations" % len(curations))
             cur_counts = {}
             for curation in curations:
+                # Update the overall counts.
                 if curation.pa_hash not in cur_counts:
                     cur_counts[curation.pa_hash] = 0
                 cur_counts[curation.pa_hash] += 1
+
+                # Work these counts into the evidence dict structure.
+                for ev_json in stmts_json[curation.pa_hash]['evidence']:
+                    if str(ev_json['source_hash']) == str(curation.source_hash):
+                        ev_json['num_curations'] = \
+                            ev_json.get('num_curations', 0) + 1
+                        break
             result['num_curations'] = cur_counts
 
         # Add derived values to the result.

--- a/rest_api/templates/search.html
+++ b/rest_api/templates/search.html
@@ -17,6 +17,18 @@
     {% endfor %}
   {% endfor %}
 
+  .badge-subject {
+    background-color: #4a36aa;
+    color: #FFFFFF;
+  }
+  .badge-object {
+    background-color: #2d8e4c;
+    color: #FFFFFF;
+  }
+  .badge-other {
+    background-color: #606060;
+    color: #FFFFFF;
+  }
   .badge-source {
     font-size: 8pt;
     margin: 0;


### PR DESCRIPTION
Optionally include curation counts in results from database searches at all levels. This implementation is naive and simple, but works because curations are currently few and far between. If they ever become more common (probably 100x more common would start to be a problem), this approach will become unmanageable. However in the meantime it works.