### PR TITLE
Apply a couple of minor Fixes

### DIFF
--- a/indra_db/client/principal/raw_statements.py
+++ b/indra_db/client/principal/raw_statements.py
@@ -66,7 +66,7 @@ def get_raw_stmt_jsons_from_papers(id_list, id_type='pmid', db=None):
         if 'text_refs' not in ev.keys():
             ev['text_refs'] = {}
         for idt in ['trid', 'pmid', 'pmcid', 'doi']:
-            ev['text_refs'][idt] = _get_id_col(tr, idt)
+            ev['text_refs'][idt.upper()] = _get_id_col(tr, idt)
 
         # Add this to the results.
         result_dict[id_val].append(rjson)

--- a/indra_db/managers/content_manager.py
+++ b/indra_db/managers/content_manager.py
@@ -947,7 +947,7 @@ class PmcManager(_NihManager):
             filtered_tc_records,
             self.tc_cols
             )
-        gatherer.add('content', len(filtered_tr_records))
+        gatherer.add('content', len(filtered_tc_records))
         return
 
     def get_data_from_xml_str(self, xml_str, filename):


### PR DESCRIPTION
This PR includes a fix to
- the `raw_statements` client, making keys into `text_refs` upper case, to overwrite any prior bad keys that were inserted by the reader.
- the content manager responsible for PMC content, making it so we actually count added content, not just added refs (again).