### PR TITLE
Upload xDD content

### DIFF
--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -140,7 +140,7 @@ readers = {'REACH': 1, 'SPARSER': 2, 'TRIPS': 3, 'ISI': 4}
 # Specify versions of readers, and preference. Later in the list is better.
 reader_versions = {
     'sparser': ['sept14-linux\n', 'sept14-linux', 'June2018-linux',
-                'October2018-linux'],
+                'October2018-linux', 'February2020-linux'],
     'reach': ['61059a-biores-e9ee36', '1.3.3-61059a-biores-'],
     'trips': ['STATIC', '2019Nov14'],
     'isi': ['20180503']

--- a/indra_db/managers/content_manager.py
+++ b/indra_db/managers/content_manager.py
@@ -299,7 +299,15 @@ class ContentManager(object):
                        if entry[id_idx(id_type)] is not None]
             # Add SqlAlchemy filter clause based on the ID list for this ID type
             if id_list:
-                or_list.append(getattr(db.TextRef, id_type).in_(id_list))
+                if id_type == 'pmid':
+                    term = db.TextRef.pmid_in(id_list)
+                elif id_type == 'pmcid':
+                    term = db.TextRef.pmcid_in(id_list)
+                elif id_type == 'doi':
+                    term = db.TextRef.doi_in(id_list)
+                else:
+                    term = getattr(db.TextRef, id_type).in_(id_list)
+                or_list.append(term)
         if len(or_list) == 1:
             tr_list = db.select_all(db.TextRef, or_list[0])
         else:

--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -113,7 +113,10 @@ class BulkReadingManager(ReadingManager):
         raise NotImplementedError("_run_reading must be defined in child.")
 
     def _get_constraints(self, db, reader_name):
-        constrains = []
+        # Ignore xDD placeholders.
+        constrains = [db.TextContent.format != 'xdd']
+
+        # Only read titles for TRIPS.
         if reader_name.lower() == 'trips':
             constrains.append(db.TextContent.text_type == "title")
         return constrains

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -292,7 +292,8 @@ class DatabaseReader(object):
         # Get the text content query object
         tc_query = self._db.filter_query(
             self._db.TextContent,
-            self._db.TextContent.id.in_(self.tcids)
+            self._db.TextContent.id.in_(self.tcids),
+            self._db.TextContent.source != 'xdd'
             )
 
         if self.reading_mode != 'all':
@@ -359,7 +360,8 @@ class DatabaseReader(object):
                 db.Reading,
                 db.Reading.reader == self.reader.name,
                 db.Reading.reader_version == self.reader.get_version()[:20],
-                db.Reading.text_content_id.in_(self.tcids)
+                db.Reading.text_content_id.in_(self.tcids),
+                db.Reading.format != 'xdd'
                 )
             for r in readings_query.yield_per(self.batch_size):
                 self.extant_readings.append(

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -34,6 +34,15 @@ class ReadDBError(Exception):
     pass
 
 
+def generate_reading_id(tcid, reader_name, reader_version):
+    reading_id = readers[reader_name.upper()] * 10e12
+    reading_id += (reader_versions[reader_name.lower()]
+                   .index(reader_version[:20]) * 10e10)
+    reading_id += tcid
+    reading_id = int(reading_id)
+    return reading_id
+
+
 class DatabaseReadingData(ReadingData):
     """This version of ReadingData adds valuable methods for database ops.
 
@@ -109,11 +118,9 @@ class DatabaseReadingData(ReadingData):
 
     def get_id(self):
         if self.reading_id is None:
-            self.reading_id = readers[self.reader_class.name.upper()]*10e12
-            self.reading_id += (reader_versions[self.reader_class.name.lower()]
-                                .index(self.reader_version[:20])*10e10)
-            self.reading_id += self.tcid
-            self.reading_id = int(self.reading_id)
+            self.reading_id = generate_reading_id(self.tcid,
+                                                  self.reader_class.__name__,
+                                                  self.reader_version)
         return self.reading_id
 
     def matches(self, r_entry):

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -65,7 +65,8 @@ def get_schema(Base):
                     BtreeIndex('text_ref_pmid_num_idx', 'pmid_num'),
                     BtreeIndex('text_ref_pmcid_num_idx', 'pmcid_num'),
                     BtreeIndex('text_ref_doi_ns_idx', 'doi_ns'),
-                    BtreeIndex('text_ref_doi_id_idx', 'doi_id')]
+                    BtreeIndex('text_ref_doi_id_idx', 'doi_id'),
+                    StringIndex('text_ref_doi_idx', 'doi')]
 
         id = Column(Integer, primary_key=True)
         pmid = Column(String(20))
@@ -95,28 +96,35 @@ def get_schema(Base):
 
         @staticmethod
         def process_pmcid(pmcid):
-            if not pmcid or not pmcid.startswith('PMC'):
+            if not pmcid:
                 return None, None
+
+            if not pmcid.startswith('PMC'):
+                return pmcid, None
+
             return pmcid, int(pmcid[3:])
 
         @staticmethod
         def process_doi(doi):
             # Check for invalid DOIs
-            if not doi or not doi.startswith('10.'):
+            if not doi:
                 return None, None, None
 
             # Regularize case.
             doi = doi.upper()
 
+            if not doi.startswith('10.'):
+                return doi, None, None
+
             # Split up the parts of the DOI
             parts = doi.split('/')
             if len(parts) < 2:
-                return None, None, None
+                return doi, None, None
 
             # Check the namespace number, make it an integer.
             namespace_str = parts[0]
             if not namespace_str.isdigit():
-                return None, None, None
+                return doi, None, None
             namespace = int(namespace_str)
 
             # Join the res of the parts together.

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -124,7 +124,7 @@ def get_schema(Base):
                 return doi, None, None
 
             # Split up the parts of the DOI
-            parts = doi.split('/')
+            parts = doi[3:].split('/')
             if len(parts) < 2:
                 return doi, None, None
 

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -27,39 +27,6 @@ def get_schema(Base):
         __tablename__ = 'text_ref'
         _ref_cols = ['pmid', 'pmcid', 'doi', 'pii', 'url', 'manuscript_id']
         _always_disp = ['id', 'pmid', 'pmcid']
-        _indices = [StringIndex('text_ref_pmid_idx', 'pmid')]
-
-        id = Column(Integer, primary_key=True)
-        pmid = Column(String(20))
-        pmcid = Column(String(20))
-        doi = Column(String(100))
-        pii = Column(String(250))
-        url = Column(String, unique=True)
-        manuscript_id = Column(String(100), unique=True)
-        create_date = Column(DateTime, default=func.now())
-        last_updated = Column(DateTime, onupdate=func.now())
-
-        __table_args__ = (
-            UniqueConstraint('pmid', 'doi', name='pmid-doi'),
-            UniqueConstraint('pmid', 'pmcid', name='pmid-pmcid'),
-            UniqueConstraint('pmcid', 'doi', name='pmcid-doi')
-        )
-
-        def get_ref_dict(self):
-            ref_dict = {}
-            for ref in self._ref_cols:
-                val = getattr(self, ref, None)
-                if val:
-                    ref_dict[ref.upper()] = val
-            ref_dict['TRID'] = self.id
-            return ref_dict
-
-    table_dict[TextRef.__tablename__] = TextRef
-
-    class TextRef2(Base, IndraDBTable):
-        __tablename__ = 'text_ref_2'
-        _ref_cols = ['pmid', 'pmcid', 'doi', 'pii', 'url', 'manuscript_id']
-        _always_disp = ['id', 'pmid', 'pmcid']
         _indices = [StringIndex('text_ref_pmid_idx', 'pmid'),
                     StringIndex('text_ref_pmcid_idx', 'pmcid'),
                     BtreeIndex('text_ref_pmid_num_idx', 'pmid_num'),
@@ -148,7 +115,7 @@ def get_schema(Base):
             ref_dict['TRID'] = self.id
             return ref_dict
 
-    table_dict[TextRef2.__tablename__] = TextRef2
+    table_dict[TextRef.__tablename__] = TextRef
 
     class MeshRefAnnotations(Base, IndraDBTable):
         __tablename__ = 'mesh_ref_annotations'

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -73,6 +73,7 @@ def get_schema(Base):
         pmid_num = Column(Integer)
         pmcid = Column(String(20))
         pmcid_num = Column(Integer)
+        pmcid_version = Column(Integer)
         doi = Column(String(100))
         doi_ns = Column(Integer)
         doi_id = Column(String)
@@ -97,12 +98,18 @@ def get_schema(Base):
         @staticmethod
         def process_pmcid(pmcid):
             if not pmcid:
-                return None, None
+                return None, None, None
 
             if not pmcid.startswith('PMC'):
-                return pmcid, None
+                return pmcid, None, None
 
-            return pmcid, int(pmcid[3:])
+            if '.' in pmcid:
+                pmcid, version_number_str = pmcid.split('.')
+                version_number = int(version_number_str)
+            else:
+                version_number = None
+
+            return pmcid, int(pmcid[3:]), version_number
 
         @staticmethod
         def process_doi(doi):

--- a/indra_db/upload_xdd_results.py
+++ b/indra_db/upload_xdd_results.py
@@ -3,7 +3,7 @@ import boto3
 from collections import defaultdict
 
 from indra.statements import Statement
-from indra_db.reading.read_db import DatabaseStatementData, DatabaseReadingData, generate_reading_id
+from indra_db.reading.read_db import DatabaseStatementData, generate_reading_id
 from indra_db.util import S3Path, get_db
 
 

--- a/indra_db/upload_xdd_results.py
+++ b/indra_db/upload_xdd_results.py
@@ -43,14 +43,12 @@ def main():
         bibs = json.loads(bib_obj['Body'].read())
         doi_lookup = {bib['_xddid']: bib['identifier'][0]['id']
                       for bib in bibs}
-        doi_vars = {doi for base_doi in doi_lookup.values()
-                            for doi in [base_doi, base_doi.upper(),
-                                        base_doi.lower()]}
+        dois = {doi for doi in doi_lookup.values()}
 
         print(f"Getting trids from database for {run_id}")
         trids = {doi.lower(): trid
                  for trid, doi in db.select_all([db.TextRef.id, db.TextRef.doi],
-                                                db.TextRef.doi.in_(doi_vars))}
+                                                db.TextRef.doi_in(dois))}
 
         try:
             stmts_obj = s3.get_object(**file_pair['stmts'].kw())

--- a/indra_db/upload_xdd_results.py
+++ b/indra_db/upload_xdd_results.py
@@ -1,0 +1,111 @@
+import json
+import boto3
+from collections import defaultdict
+
+from indra.statements import Statement
+from indra_db.reading.read_db import DatabaseStatementData, DatabaseReadingData, generate_reading_id
+from indra_db.util import S3Path, get_db
+
+
+BUCKET = S3Path(bucket='hms-uw-collaboration')
+XDD_READER_VERSIONS = {'REACH': '1.3.3-61059a-biores-e9ee36',
+                       'SPARSER': 'February2020-linux'}
+XDD_INDRA_VERSION = '1.16.0-c439fdbc936f4eac00cafd559927d7ee06c492e8'
+
+
+def main():
+    db = get_db('primary')
+
+    print("Looking for good xdd files.")
+    s3 = boto3.client('s3')
+    list_res = s3.list_objects_v2(**BUCKET.kw())
+    files = [BUCKET.get_element_path(e['Key']) for e in list_res['Contents']]
+    good_files = [file for file in files if not file.key.startswith('852')]
+    print(f"Found {len(good_files)} good files.")
+
+    print("Pairing up xdd files...")
+    file_pairs = defaultdict(dict)
+    for file in good_files:
+        run_id, file_suffix = file.key.split('_')
+        file_type = file_suffix.split('.')[0]
+        file_pairs[run_id][file_type] = file
+    print(f"Found {len(file_pairs)} pairs.")
+
+    print("Processing statements...")
+    run_stmts = defaultdict(lambda: defaultdict(list))
+    for run_id, file_pair in file_pairs.items():
+        print(f"Processing {run_id}")
+        try:
+            bib_obj = s3.get_object(**file_pair['bib'].kw())
+        except Exception as e:
+            print(f'ERROR on bib for {run_id}: {e}')
+            continue
+        bibs = json.loads(bib_obj['Body'].read())
+        doi_lookup = {bib['_xddid']: bib['identifier'][0]['id']
+                      for bib in bibs}
+        doi_vars = {doi for base_doi in doi_lookup.values()
+                            for doi in [base_doi, base_doi.upper(),
+                                        base_doi.lower()]}
+
+        print(f"Getting trids from database for {run_id}")
+        trids = {doi.lower(): trid
+                 for trid, doi in db.select_all([db.TextRef.id, db.TextRef.doi],
+                                                db.TextRef.doi.in_(doi_vars))}
+
+        try:
+            stmts_obj = s3.get_object(**file_pair['stmts'].kw())
+        except Exception as e:
+            print(f'ERROR on stmt for {run_id}: {e}')
+            continue
+        stmts = json.loads(stmts_obj['Body'].read())
+        for sj in stmts:
+            ev = sj['evidence'][0]
+            xddid = ev['text_refs']['CONTENT_ID']
+            ev.pop('pmid', None)
+            ev['text_refs']['DOI'] = doi_lookup[xddid]
+
+            trid = trids[doi_lookup[xddid]]
+            ev['text_refs']['TRID'] = trid
+            ev['text_refs']['XDD_RUN_ID'] = run_id
+
+            run_stmts[trid][ev['text_refs']['READER']].append(sj)
+
+    print("Dumping text content.")
+    tc_rows = {(trid, 'xdd', 'xdd', 'fulltext') for trid in run_stmts.keys()}
+    tc_cols = ('text_ref_id', 'source', 'format', 'text_type')
+    db.copy_lazy('text_content', tc_rows, tc_cols, commit=False)
+
+    print("Looking up new tcids.")
+    tcids = db.select_all([db.TextContent.text_ref_id, db.TextContent.id],
+                          db.TextContent.text_ref_id.in_(run_stmts.keys()),
+                          db.TextContent.source == 'xdd')
+    tcid_lookup = {trid: tcid for trid, tcid in tcids}
+
+    print("Compiling reading and statement rows.")
+    r_rows = set()
+    r_cols = ('id', 'text_content_id', 'reader', 'reader_version', 'format',
+              'batch_id')
+    s_rows = set()
+    s_cols = ('uuid', 'mk_hash', 'text_hash', 'source_hash', 'reading_id',
+              'type', 'indra_version', 'json')
+    for trid, trid_set in run_stmts.items():
+        for reader, stmt_list in trid_set.items():
+            tcid = tcid_lookup[trid]
+            reader_version = XDD_READER_VERSIONS[reader.upper()]
+            reading_id = generate_reading_id(tcid, reader, reader_version)
+            r_rows.add((reading_id, tcid, reader.upper(), reader_version,
+                        'xdd', db.make_copy_batch_id()))
+            for sj in stmt_list:
+                stmt = Statement._from_json(sj)
+                sd = DatabaseStatementData(stmt, reading_id)
+                s_rows.add(sd.make_tuple(db.make_copy_batch_id()))
+
+    print("Dumping reading.")
+    db.copy_lazy('reading', r_rows, r_cols, commit=False)
+
+    print("Dumping raw statements.")
+    db.copy_lazy('raw_statements', s_rows, DatabaseStatementData.get_cols())
+
+
+if __name__ == '__main__':
+    main()

--- a/indra_db/upload_xdd_results.py
+++ b/indra_db/upload_xdd_results.py
@@ -86,8 +86,6 @@ def main():
     r_cols = ('id', 'text_content_id', 'reader', 'reader_version', 'format',
               'batch_id')
     s_rows = set()
-    s_cols = ('uuid', 'mk_hash', 'text_hash', 'source_hash', 'reading_id',
-              'type', 'indra_version', 'json')
     for trid, trid_set in run_stmts.items():
         for reader, stmt_list in trid_set.items():
             tcid = tcid_lookup[trid]


### PR DESCRIPTION
This PR centers around implementing a pipeline to put the results from xDD reading into the database, with empty records added for `text_content` and `reading` tables, with the DOIs used by xDD mapped to text ref IDs to maintain linking in the database.

In part to better accomplish this task, I also refactored the `text_ref` table to enable faster lookups by IDs, in particular DOIs. This also necessitated some changes to the content manager.

Changes were also made to the reading pipeline to ensure that xDD records in content and reading are ignored for the purposes of our reading.