### PR TITLE
Add Eidos as a reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We have read all available content, and every day we run the following readers:
 
 we read all new content with the following readers:
 - [Eidos](https://github.com/clulab/eidos)
+- [ISI](https://github.com/sgarg87/big_mech_isi_gg)
 
 we read a limited subset of new content with the following readers:
 - [TRIPS](http://trips.ihmc.us/parser/cgi/drum)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ We have read all available content, and every day we run the following readers:
 - [REACH](https://github.com/clulab/reach)
 - [Sparser](https://github.com/ddmcdonald/sparser)
 
+we read all new content with the following readers:
+- [Eidos](https://github.com/clulab/eidos)
+
+we read a limited subset of new content with the following readers:
+- [TRIPS](http://trips.ihmc.us/parser/cgi/drum)
+
 on the latest content drawn from:
 - [PubMed](https://www.ncbi.nlm.nih.gov/pubmed/) - ~19 million abstracts and ~29 million titles
 - [PubMed Central](/www.ncbi.nlm.nih.gov/pmc/) - ~2.7 million fulltext
@@ -31,7 +37,6 @@ on the latest content drawn from:
 
 #### Other Readers
 We also include more or less static content extracted from the following readers:
-- [TRIPS](http://trips.ihmc.us/trac/drum/wiki/TripsDrumSystemInstallation)
 - [RLIMS-P](https://research.bioinformatics.udel.edu/rlimsp/)
 
 #### Other Databases

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -143,7 +143,8 @@ reader_versions = {
                 'October2018-linux', 'February2020-linux'],
     'reach': ['61059a-biores-e9ee36', '1.3.3-61059a-biores-'],
     'trips': ['STATIC', '2019Nov14'],
-    'isi': ['20180503']
+    'isi': ['20180503'],
+    'eidos': ['0.2.3-SNAPSHOT'],
 }
 
 

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -140,7 +140,7 @@ readers = {'REACH': 1, 'SPARSER': 2, 'TRIPS': 3, 'ISI': 4}
 # Specify versions of readers, and preference. Later in the list is better.
 reader_versions = {
     'sparser': ['sept14-linux\n', 'sept14-linux', 'June2018-linux',
-                'October2018-linux', 'February2020-linux'],
+                'October2018-linux', 'February2020-linux', 'April2020-linux'],
     'reach': ['61059a-biores-e9ee36', '1.3.3-61059a-biores-'],
     'trips': ['STATIC', '2019Nov14'],
     'isi': ['20180503'],

--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -180,14 +180,16 @@ class BulkAwsReadingManager(BulkReadingManager):
         'reach': 1200,
         'sparser': 600,
         'isi': 2400,
-        'trips': 300
+        'trips': 300,
+        'eidos': 1200,
     }
 
     ids_per_job = {
         'reach': 5000,
         'sparser': 5000,
         'isi': 5000,
-        'trips': 500
+        'trips': 500,
+        'eidos': 5000,
     }
 
     def __init__(self, *args, **kwargs):

--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -387,7 +387,7 @@ def main():
     else:
         db = get_db(args.database)
 
-    readers = ['SPARSER', 'REACH', 'TRIPS', 'ISI']
+    readers = ['SPARSER', 'REACH', 'TRIPS', 'ISI', 'EIDOS']
     if args.method == 'local':
         bulk_manager = BulkLocalReadingManager(readers,
                                                buffer_days=args.buffer,

--- a/indra_db/reading/submit_reading_pipeline.py
+++ b/indra_db/reading/submit_reading_pipeline.py
@@ -52,11 +52,13 @@ class DbReadingSubmitter(Submitter):
     """
     _s3_input_name = 'id_list'
     _purpose = 'db_reading'
-    _job_queue_dict = {'run_db_reading_queue': ['reach', 'sparser', 'isi'],
+    _job_queue_dict = {'run_db_reading_queue': ['reach', 'sparser', 'isi',
+                                                'eidos'],
                        'run_db_trips_queue': ['trips']}
     _job_def_dict = {'run_db_reading_jobdef': ['reach', 'sparser'],
                      'run_db_reading_isi_jobdef': ['isi'],
-                     'run_db_reading_trips_jobdef': ['trips']}
+                     'run_db_reading_trips_jobdef': ['trips'],
+                     'run_db_reading_eidos_jobdef': ['eidos']}
 
     def __init__(self, *args, **kwargs):
         super(DbReadingSubmitter, self).__init__(*args, **kwargs)

--- a/indra_db/schemas/readonly_schema.py
+++ b/indra_db/schemas/readonly_schema.py
@@ -549,4 +549,4 @@ SOURCE_GROUPS = {'databases': ['phosphosite', 'cbn', 'pc11', 'biopax',
                                'bel_lc', 'signor', 'biogrid', 'tas',
                                'lincs_drug', 'hprd', 'trrust'],
                  'reading': ['geneways', 'tees', 'isi', 'trips', 'rlimsp',
-                             'medscan', 'sparser', 'reach']}
+                             'medscan', 'sparser', 'reach', 'eidos']}


### PR DESCRIPTION
This PR builds on https://github.com/indralab/indra_reading/pull/5 to add Eidos as a reader in this repo (though I might have missed some places!). The Docker architecture is currently defined such that the image in which Eidos runs (indra_eidos_reading_docker) is built on top of indra_db_docker, therefore we'd have to merge the changes here, rebuild indra_db_docker, and then build the indra_eidos_reading_docker on top of that (if this setup is not workable, there are alternatives that we can try).