### PR TITLE
Fix minor bugs in preassembly

### DIFF
--- a/indra_db/managers/preassembly_manager.py
+++ b/indra_db/managers/preassembly_manager.py
@@ -176,7 +176,7 @@ class PreassemblyManager(object):
         evidence_links = defaultdict(lambda: set())
         agent_tuples = set()
         for s in cleaned_stmts:
-            h = shash(s)
+            h = s.get_hash(refresh=True)
 
             # If this statement is new, make it.
             if h not in mk_done and h not in new_mk_set:

--- a/indra_db/util/insert.py
+++ b/indra_db/util/insert.py
@@ -344,7 +344,7 @@ def insert_pa_stmts(db, stmts, verbose=False, do_copy=True,
     if do_copy:
         db.copy('pa_statements', stmt_data, cols, commit=False)
         db.copy('pa_activity', activity_rows,
-                ('mk_hash', 'activity', 'is_active'), commit=commit)
+                ('stmt_mk_hash', 'activity', 'is_active'), commit=commit)
     else:
         db.insert_many('pa_statements', stmt_data, cols=cols)
     if not ignore_agents:


### PR DESCRIPTION
Recalculate hash before all comparisons to ensure it matches insert, preventing hash conflicts on-insert. Also fixes name of column for new activity table.