### PR TITLE
Update the Readonly Dump to include resource files.

### DIFF
--- a/indra_db/belief.py
+++ b/indra_db/belief.py
@@ -178,6 +178,7 @@ def get_belief(db=None, partition=True):
             if len(group) >= 100000:
                 stmts = load_mock_statements(db, hashes=group)
                 beliefs.update(calculate_belief(stmts))
+                group = set()
         return beliefs
     else:
         stmts = load_mock_statements(db)

--- a/indra_db/belief.py
+++ b/indra_db/belief.py
@@ -11,6 +11,7 @@ import argparse
 from datetime import datetime
 
 from indra_db import util as dbu
+from indra_db.util import S3Path
 from indra_db.util.dump_sif import upload_pickle_to_s3, S3_SUBDIR
 
 logger = logging.getLogger('db_belief')
@@ -161,8 +162,10 @@ if __name__ == '__main__':
                               datetime.utcnow().strftime('%Y-%m-%d'),
                               args.fname]) if args.s3 else args.fname
     belief_dict = get_belief()
-    if fname.startswith('s3:'):
-        upload_pickle_to_s3(obj=belief_dict, key=fname)
+    if args.s3:
+        key = '/'.join([datetime.utcnow().strftime('%Y-%m-%d'), args.fname])
+        s3_path = S3Path(S3_SUBDIR, key)
+        upload_pickle_to_s3(obj=belief_dict, s3_path=s3_path)
     else:
-        with open(fname, 'wb') as f:
+        with open(args.fname, 'wb') as f:
             pickle.dump(belief_dict, f)

--- a/indra_db/belief.py
+++ b/indra_db/belief.py
@@ -175,7 +175,7 @@ def get_belief(db=None, partition=True):
         for c in nx.connected_components(g):
             group |= c
 
-            if len(group) >= 100000:
+            if len(group) >= 10000:
                 stmts = load_mock_statements(db, hashes=group)
                 beliefs.update(calculate_belief(stmts))
                 group = set()

--- a/indra_db/belief.py
+++ b/indra_db/belief.py
@@ -47,6 +47,9 @@ class MockStatement(object):
     def matches_key(self):
         return self.__mk_hash
 
+    def get_hash(self):
+        return self.__mk_hash
+
 
 class MockEvidence(object):
     """A class to imitate real INDRA Evidence for calculating belief."""

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -86,8 +86,8 @@ class SourceCount(Dumper):
         get_source_counts(self.get_s3_path(), db)
 
 
-class FullPA(Dumper):
-    name = 'full_pa'
+class FullPaJson(Dumper):
+    name = 'full_pa_json'
     fmt = 'json'
 
     def dump(self, continuing=False):

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -9,7 +9,7 @@ from indra_db.belief import get_belief
 from indra_db.config import CONFIG
 from indra_db.config import get_s3_dump
 from indra_db.util import get_db, get_ro, S3Path
-from indra_db.util.dump_sif import dump_sif
+from indra_db.util.dump_sif import dump_sif, get_source_counts
 
 
 logger = logging.getLogger(__name__)
@@ -73,6 +73,15 @@ class Belief(Dumper):
         belief_dict = get_belief(db)
         s3 = boto3.client('s3')
         s3.put_object(Body=json.dumps(belief_dict), **self.get_s3_path().kw())
+
+
+class SourceCount(Dumper):
+    name = 'source_count'
+    fmt = 'pkl'
+
+    def dump(self, continuing=False):
+        db = get_db(self.db_label)
+        src_count = get_source_counts(self.get_s3_path(), db)
 
 
 class Readonly(Dumper):

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -29,20 +29,23 @@ class Dumper(object):
     name = NotImplemented
     fmt = NotImplemented
 
-    def __init__(self, db_label='primary'):
+    def __init__(self, db_label='primary', date=None):
         self.db_label = db_label
         self.s3_dump_path = None
+        if date is None:
+            self.date_stamp = datetime.now().strftime('%Y-%m-%d')
+        else:
+            self.date_stamp = date.strftime('%Y-%m-%d')
 
     def get_s3_path(self):
         if self.s3_dump_path is None:
             self.s3_dump_path = self._gen_s3_name()
         return self.s3_dump_path
 
-    @classmethod
-    def _gen_s3_name(cls):
+    def _gen_s3_name(self):
         s3_base = get_s3_dump()
-        dt_ts = datetime.now().strftime('%Y-%m-%d')
-        s3_path = s3_base.get_element_path(dt_ts, '%s.%s' % (cls.name, cls.fmt))
+        s3_path = s3_base.get_element_path(self.date_stamp,
+                                           '%s.%s' % (self.name, self.fmt))
         return s3_path
 
     def dump(self, continuing=False):

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -33,7 +33,7 @@ class Dumper(object):
 
     def get_s3_path(self):
         if self.s3_dump_path is None:
-            self.s3_dump_path= self._gen_s3_name()
+            self.s3_dump_path = self._gen_s3_name()
         return self.s3_dump_path
 
     @classmethod

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -84,6 +84,19 @@ class SourceCount(Dumper):
         get_source_counts(self.get_s3_path(), db)
 
 
+class FullPA(Dumper):
+    name = 'full_pa'
+    fmt = 'json'
+
+    def dump(self, continuing=False):
+        db = get_db(self.db_label)
+        query_res = db.filter_query(db.FastRaw)
+        # todo test if it's possible to skip str -> json -> str steps
+        json_list = [json.loads(js[0]) for js in query_res.all()]
+        s3 = boto3.client('s3')
+        s3.put_object(Body=json.dumps(json_list), **self.get_s3_path().kw())
+
+
 class Readonly(Dumper):
     name = 'readonly'
     fmt = 'dump'

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -66,7 +66,7 @@ class Sif(Dumper):
 
 class Belief(Dumper):
     name = 'belief'
-    fmt = 'pkl'
+    fmt = 'json'
 
     def dump(self, continuing=False):
         db = get_db(self.db_label)

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -81,7 +81,7 @@ class SourceCount(Dumper):
 
     def dump(self, continuing=False):
         db = get_db(self.db_label)
-        src_count = get_source_counts(self.get_s3_path(), db)
+        get_source_counts(self.get_s3_path(), db)
 
 
 class Readonly(Dumper):

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -266,6 +266,9 @@ def main():
         logger.info("Dumping sif from the readonly schema on principal.")
         Sif(use_principal=True).dump(continuing=args.allow_continue)
 
+        logger.info("Dumping all PA Statements as a pickle.")
+        FullPaStmts(use_principal=True).dump(continuing=args.allow_continue)
+
         logger.info("Dumping belief.")
         Belief().dump(continuing=args.allow_continue)
         dump_file = ro_dumper.get_s3_path()

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -99,7 +99,7 @@ class FullPaJson(Dumper):
             ro = get_db(self.db_label)
         else:
             ro = get_ro(self.db_label)
-        query_res = ro.filter_query(ro.FastRawPaLink.pa_json.distinct())
+        query_res = ro.session.query(ro.FastRawPaLink.pa_json.distinct())
         json_list = [json.loads(js[0]) for js in query_res.all()]
         s3 = boto3.client('s3')
         s3.put_object(Body=json.dumps(json_list), **self.get_s3_path().kw())
@@ -118,7 +118,7 @@ class FullPaStmts(Dumper):
             ro = get_db(self.db_label)
         else:
             ro = get_ro(self.db_label)
-        query_res = ro.filter_query(ro.FastRawPaLink.pa_json.distinct())
+        query_res = ro.session.query(ro.FastRawPaLink.pa_json.distinct())
         stmt_list = stmts_from_json([json.loads(js[0]) for js in
                                      query_res.all()])
         s3 = boto3.client('s3')

--- a/indra_db/schemas/readonly_schema.py
+++ b/indra_db/schemas/readonly_schema.py
@@ -229,7 +229,8 @@ def get_schema(Base):
             '  AND pa_statements.mk_hash = readonly.evidence_counts.mk_hash\n'
             '  AND readonly.pa_agent_counts.mk_hash = pa_agents.stmt_mk_hash\n'
             '  AND pa_statements.type = type_map.type\n'
-            '  AND pa_agents.role = role_map.role'
+            '  AND pa_agents.role = role_map.role\n'
+            '  AND LENGTH(pa_agents.db_id) < 50'
         )
         _indices = [StringIndex('pa_meta_db_name_idx', 'db_name'),
                     StringIndex('pa_meta_db_id_idx', 'db_id'),

--- a/indra_db/schemas/readonly_schema.py
+++ b/indra_db/schemas/readonly_schema.py
@@ -230,7 +230,7 @@ def get_schema(Base):
             '  AND readonly.pa_agent_counts.mk_hash = pa_agents.stmt_mk_hash\n'
             '  AND pa_statements.type = type_map.type\n'
             '  AND pa_agents.role = role_map.role\n'
-            '  AND LENGTH(pa_agents.db_id) < 50'
+            '  AND LENGTH(pa_agents.db_id) < 2000'
         )
         _indices = [StringIndex('pa_meta_db_name_idx', 'db_name'),
                     StringIndex('pa_meta_db_id_idx', 'db_id'),

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -301,7 +301,7 @@ def get_parser():
 
 
 def dump_sif(df_file=None, db_res_file=None, csv_file=None, src_count_file=None,
-             reload=False, reconvert=False, ro=None):
+             reload=False, reconvert=True, ro=None):
     if ro is None:
         ro = get_db('primary')
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 
 from indra.util.aws import get_s3_client
 from indra_db.schemas.readonly_schema import ro_type_map
+from indra.statements.agent import default_ns_order
 
 try:
     import pandas as pd
@@ -25,22 +26,8 @@ logger = logging.getLogger(__name__)
 S3_SIF_BUCKET = 'bigmech'
 S3_SUBDIR = 'indra_db_sif_dump'
 
-NS_PRIORITY_LIST = (
-    'FPLX',
-    'MIRBASE',
-    'HGNC',
-    'GO',
-    'MESH',
-    'HMDB',
-    'CHEBI',
-    'PUBCHEM',
-)
-
-
-# All namespaces here (except NAME) should also be included in the
-# NS_PRIORITY_LIST above
-NS_LIST = ('NAME', 'MIRBASE', 'HGNC', 'FPLX', 'GO', 'MESH', 'HMDB', 'CHEBI',
-           'PUBCHEM')
+NS_PRIORITY_LIST = tuple(default_ns_order)
+NS_LIST = ('NAME', ) + NS_PRIORITY_LIST
 
 
 def _pseudo_key(fname, ymd_date):

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -119,13 +119,8 @@ def get_source_counts(pkl_filename=None, ro=None):
         pkl_filename = S3Path.from_string(pkl_filename)
     if not ro:
         ro = get_ro('primary-ro')
-    res = ro.select_all(ro.PaStmtSrc)
-    ev = {}
-    for r in res:
-        rd = r.__dict__
-        ev[rd['mk_hash']] = {k: v for k, v in rd.items() if
-                             k not in ['_sa_instance_state', 'mk_hash'] and
-                             rd[k] is not None}
+    ev = {h: j for h, j in ro.select_all([ro.SourceMeta.mk_hash,
+                                          ro.SourceMeta.src_json])}
 
     if pkl_filename:
         if isinstance(pkl_filename, S3Path):

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -10,6 +10,7 @@ from itertools import permutations
 from collections import OrderedDict
 
 from indra.util.aws import get_s3_client
+from indra_db.schemas.readonly_schema import ro_type_map
 
 try:
     import pandas as pd
@@ -85,10 +86,11 @@ def load_db_content(ns_list, pkl_filename=None, ro=None, reload=False):
             logger.info("Querying for {ns}".format(ns=ns))
             res = ro.select_all([ro.PaMeta.mk_hash, ro.PaMeta.db_name,
                                  ro.PaMeta.db_id, ro.PaMeta.ag_num,
-                                 ro.PaMeta.ev_count, ro.PaMeta.type],
+                                 ro.PaMeta.ev_count, ro.PaMeta.type_num],
                                 ro.PaMeta.db_name.like(ns))
             results.extend(res)
-        results = set(results)
+        results = {(h, dbn, dbi, ag_num, ev_cnt, ro_type_map.get_str(tn))
+                   for h, dbn, dbi, ag_num, ev_cnt, tn in results}
         if pkl_filename:
             if isinstance(pkl_filename, S3Path):
                 upload_pickle_to_s3(results, pkl_filename)

--- a/indra_db/util/s3_path.py
+++ b/indra_db/util/s3_path.py
@@ -20,6 +20,16 @@ class S3Path(object):
             raise ValueError(f"Cannot compare with type \"{type(other)}\".")
         return self.to_string() < other.to_string()
 
+    def __eq__(self, other):
+        if not isinstance(other, S3Path):
+            raise ValueError(f"Cannot compare with type \"{type(other)}\".")
+        return self.to_string() == other.to_string()
+
+    def __le__(self, other):
+        if not isinstance(other, S3Path):
+            raise ValueError(f"Cannot compare with type \"{type(other)}\".")
+        return self.to_string() <= other.to_string()
+
     def kw(self, prefix=False):
         ret = {'Bucket': self.bucket}
         if self.key:

--- a/indra_db/util/s3_path.py
+++ b/indra_db/util/s3_path.py
@@ -15,6 +15,11 @@ class S3Path(object):
                 key = key[1:]
         self.key = key
 
+    def __lt__(self, other):
+        if not isinstance(other, S3Path):
+            raise ValueError(f"Cannot compare with type \"{type(other)}\".")
+        return self.to_string() < other.to_string()
+
     def kw(self, prefix=False):
         ret = {'Bucket': self.bucket}
         if self.key:


### PR DESCRIPTION
This PR generalizes the "dump" as a class that incorporates various resources, and coordinates their generation, which is inter-related. This includes:
- the sif dump,
- the belief dump,
- the readonly database dump, and
- a dump of all pa statements as a pickle (or JSON)

The code in this branch has been tested and shown to work with only minor final modifications. It has also been improved to better allow continuation after a failed run, which was thoroughly tested. Last of all, machinery was added that ensured dumps all end up grouped together, as they should be, even when they run into a new day. These changes were integral with the changes allowing a dump to continue.
