### PR TITLE
Fix read db

### DIFF
--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -515,6 +515,14 @@ class DatabaseManager(object):
                     len(entry_list))
         return
 
+    def get_copy_cursor(self):
+        """Execute SQL queries in the context of a copy operation."""
+        # Prep the connection.
+        if self._conn is None:
+            self._conn = self.engine.raw_connection()
+            self._conn.rollback()
+        return self._conn.cursor()
+
     def make_copy_batch_id(self):
         """Generate a random batch id for copying into the database.
 

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -486,7 +486,8 @@ class DatabaseReader(object):
         # Dump the duplicates into a separate to all for debugging.
         self._db.copy('rejected_statements', [tpl for dlist in dups.values()
                                               for tpl in dlist],
-                      DatabaseStatementData.get_cols())
+                      DatabaseStatementData.get_cols(),
+                      commit=False)
 
         # Add the agents for the accepted statements.
         logger.info("Uploading agents to the database.")

--- a/indra_db/util/insert.py
+++ b/indra_db/util/insert.py
@@ -45,7 +45,6 @@ def insert_raw_agents(db, batch_id, stmts=None, verbose=False,
     ref_tuples = []
     mod_tuples = []
     mut_tuples = []
-    cur = db._conn.cursor()
     if stmts is None:
         s_col = 'json'
         stmt_dict = None
@@ -53,6 +52,7 @@ def insert_raw_agents(db, batch_id, stmts=None, verbose=False,
         s_col = 'uuid'
         stmt_dict = {s.uuid: s for s in stmts}
 
+    cur = db.get_copy_cursor()
     cur.execute(f'SELECT id, {s_col} FROM raw_statements WHERE batch_id=%s',
                 (batch_id,))
     if verbose:


### PR DESCRIPTION
This PR fixes a minor issue in the dumping of statements after reading with regard to session management. Specifically, do not commit before inserting agents; this allows the entire process of inserting statements and inserting agents to occur as part of one single transaction that succeeds and fails as one, avoiding statements existing without agents and such.