### PR TITLE
New knowledge bases

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ We include the information from these pre-existing databases:
 - [TRRUST](https://omictools.com/trrust-tool)
 - [PhosphoSitePlus](https://www.phosphosite.org/)
 - [Causal Biological Networks Database](http://www.causalbionet.com/)
+- [VirHostNet](http://virhostnet.prabi.fr/)
+- [CTD](http://ctdbase.org/)
+- [Phospho.ELM](http://phospho.elm.eu.org/)
 
 These databases are retrieved primarily using the tools in `indra.sources`. The
 statements extracted from all of these sources are stored and updated in the

--- a/indra_db/managers/knowledgebase_manager.py
+++ b/indra_db/managers/knowledgebase_manager.py
@@ -189,6 +189,27 @@ class PathwayCommonsManager(KnowledgebaseManager):
         return filtered_stmts
 
 
+class CTDManager(KnowledgebaseManager):
+    name = 'ctd'
+    source = 'ctd'
+    subsets = ['gene_disease', 'chemical_disease',
+               'chemical_gene']
+
+    def __init__(self, *args, **kwargs):
+        self.counts = defaultdict(lambda: 0)
+        super().__init__(*args, **kwargs)
+
+    def _get_statements(self):
+        s3 = boto3.client('s3')
+        all_stmts = []
+        for subset in self.subsets:
+            key = 'indra-db/ctd_%s.pkl' % subset
+            resp = s3.get_object(Bucket='bigmech', Key=key)
+            stmts = pickle.loads(resp['Body'].read())
+            all_stmts += [s for s in _expanded(stmts)]
+        return all_stmts
+
+
 class HPRDManager(KnowledgebaseManager):
     name = 'hprd'
     source = 'hprd'

--- a/indra_db/managers/knowledgebase_manager.py
+++ b/indra_db/managers/knowledgebase_manager.py
@@ -163,7 +163,8 @@ class BiogridManager(KnowledgebaseManager):
 class PathwayCommonsManager(KnowledgebaseManager):
     name = 'pc11'
     source = 'biopax'
-    skips = {'psp', 'hprd', 'biogrid', 'phosphosite', 'phosphositeplus'}
+    skips = {'psp', 'hprd', 'biogrid', 'phosphosite', 'phosphositeplus',
+             'ctd'}
 
     def __init__(self, *args, **kwargs):
         self.counts = defaultdict(lambda: 0)

--- a/indra_db/managers/knowledgebase_manager.py
+++ b/indra_db/managers/knowledgebase_manager.py
@@ -1,6 +1,7 @@
 __all__ = ['TasManager', 'CBNManager', 'HPRDManager', 'SignorManager',
            'BiogridManager', 'BelLcManager', 'PathwayCommonsManager',
-           'RlimspManager', 'TrrustManager', 'PhosphositeManager']
+           'RlimspManager', 'TrrustManager', 'PhosphositeManager',
+           'CTDManager', 'VirHostNetManager', 'PhosphoElmManager']
 
 import os
 import zlib


### PR DESCRIPTION
This PR adds 3 new knowledge base managers for CTD, VirHostNet and Phospho.ELM, prepared such that it can be processed in this context without complex workflows.