### PR TITLE
Allow multiple MeSH operations via web API

### DIFF
--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -412,7 +412,7 @@ def _db_query_from_web_query(query_dict, require=None, empty_web_query=False):
 
 
     # Check for health of the resulting query, and some other things.
-    if isinstance(db_query, EmptyDBQuery):
+    if isinstance(db_query, EmptyQuery):
         raise DbAPIError(f"No arguments from web query {query_dict} mapped to "
                          f"db query.")
     assert isinstance(db_query, QueryCore), "Somehow db_query is not QueryCore."


### PR DESCRIPTION
This PR adds support for interpreting lists of MeSH IDs using a logical `or` operation between them via the web API. This is important to support queries where we ask: "is there support for a statement from _a given MeSH term or any of its children_", which is needed in some downstream applications. If this is not the right approach for doing this, feel free to implement it some other way @pagreene. 