### PR TITLE
Expand allowed characters in bucket name

### DIFF
--- a/indra_db/util/s3_path.py
+++ b/indra_db/util/s3_path.py
@@ -68,7 +68,7 @@ class S3Path(object):
 
     @classmethod
     def from_string(cls, s3_key_str):
-        patt = re.compile('s3://([a-z0-9]+)/(.*)')
+        patt = re.compile('s3://([a-z0-9\-.]+)/(.*)')
         m = patt.match(s3_key_str)
         if m is None:
             raise ValueError("Invalid format for s3 path: %s" % s3_key_str)


### PR DESCRIPTION
This PR adds the characters "." and "-" to the allowed characters in S3 bucket names. This makes the regex check compatible with all the allowed characters for bucket names (see [AWS S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules)).

I tested the regex in PyCharm.