### PR TITLE
Avoid/handle mesh ref results without pmids.

### DIFF
--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -120,6 +120,10 @@ class BulkReadingManager(ReadingManager):
         # Only read titles for TRIPS.
         if reader_name.lower() == 'trips':
             constrains.append(db.TextContent.text_type == "title")
+        elif reader_name.lower() == 'mti':
+            constrains.append(
+                db.TextContent.text_type.in_(['title', 'abstract'])
+            )
         return constrains
 
     @ReadingManager._run_all_readers

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -94,6 +94,12 @@ class DatabaseReadingData(ReadingData):
                    db_reading.reader_version, db_reading.format,
                    reading, db_reading.id)
 
+    @classmethod
+    def from_json(cls, jd):
+        # Remove redundant ID that doesn't show up in the JSON.
+        jd['tcid'] = jd.pop('content_id')
+        return super(DatabaseReadingData, cls).from_json(jd)
+
     @staticmethod
     def get_cols():
         """Get the columns for the tuple returned by `make_tuple`."""

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -530,12 +530,17 @@ class DatabaseReader(object):
                     rslt_data = DatabaseStatementData(
                         rslt, reading_data.reading_id)
                 else:
-                    pmid = self._db.select_one(
+                    pmid_tpl = self._db.select_one(
                         self._db.TextRef.pmid_num,
                         self._db.TextContent.id == reading_data.content_id,
                         self._db.TextContent.text_ref_id == self._db.TextRef.id
                     )
-                    rslt_tuple = (pmid[0], rslt)
+                    pmid = pmid_tpl[0]
+                    if pmid is None:
+                        logger.warning(f"No PMID found for "
+                                       f"tcid={reading_data.content_id}")
+                        continue
+                    rslt_tuple = (pmid, rslt)
                     rslt_data = DatabaseMeshRefData(
                         rslt_tuple, reading_data.reading_id)
                 rslt_data_list.append(rslt_data)


### PR DESCRIPTION
Avoid content without pmids and speed up reading by constraining the content retrieved by constraining to titles and abstracts. This will also eliminate much of the content that might not have a PMID. As an added measure though, also implement graceful handling of missing PMIDs when dumping MTI results by simply skipping such records with a warning.