### PR TITLE
Add an argument for batching content reading.

### DIFF
--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -209,6 +209,7 @@ class BulkAwsReadingManager(BulkReadingManager):
 
     def __init__(self, *args, **kwargs):
         self.project_name = kwargs.pop('project_name', None)
+        self.batch_batch = kwargs.pop('batch_batch', None)
         super(BulkAwsReadingManager, self).__init__(*args, **kwargs)
         self.reader_versions = {}
         return
@@ -241,7 +242,8 @@ class BulkAwsReadingManager(BulkReadingManager):
         logger.info("Submitting jobs...")
         sub = DbReadingSubmitter(basename, [reader_name.lower()],
                                  project_name=self.project_name,
-                                 group_name=group_name)
+                                 group_name=group_name,
+                                 batch_batch=self.batch_batch)
         sub.submit_reading(file_name, 0, None,
                            self.ids_per_job[reader_name.lower()])
 
@@ -370,6 +372,12 @@ def get_parser():
               'which this reading is being done. This is used to label jobs '
               'on aws batch for monitoring and accounting purposes.')
     )
+    aws_read_parser.add_argument(
+        '-B', '--batch-batch',
+        default=None,
+        type=int,
+        help="Specify the size of batches within each batch instance."
+    )
     subparsers = parser.add_subparsers(title='Method')
     subparsers.required = True
     subparsers.dest = 'method'
@@ -417,7 +425,8 @@ def main():
         bulk_manager = BulkAwsReadingManager(readers,
                                              buffer_days=args.buffer,
                                              project_name=args.project_name,
-                                             only_unread=args.only_unread)
+                                             only_unread=args.only_unread,
+                                             batch_batch=args.batch_batch)
     else:
         assert False, "This shouldn't be allowed."
 

--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -204,7 +204,7 @@ class BulkAwsReadingManager(BulkReadingManager):
         'isi': 5000,
         'trips': 500,
         'eidos': 5000,
-        'mti': 1000,
+        'mti': None,  # meaning all content run in a single job.
     }
 
     batch_batch = {

--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -207,9 +207,12 @@ class BulkAwsReadingManager(BulkReadingManager):
         'mti': 1000,
     }
 
+    batch_batch = {
+        'mti': 10
+    }
+
     def __init__(self, *args, **kwargs):
         self.project_name = kwargs.pop('project_name', None)
-        self.batch_batch = kwargs.pop('batch_batch', None)
         super(BulkAwsReadingManager, self).__init__(*args, **kwargs)
         self.reader_versions = {}
         return
@@ -243,7 +246,7 @@ class BulkAwsReadingManager(BulkReadingManager):
         sub = DbReadingSubmitter(basename, [reader_name.lower()],
                                  project_name=self.project_name,
                                  group_name=group_name,
-                                 batch_batch=self.batch_batch)
+                                 batch_batch=self.batch_batch.get(reader_name))
         sub.submit_reading(file_name, 0, None,
                            self.ids_per_job[reader_name.lower()])
 
@@ -372,12 +375,6 @@ def get_parser():
               'which this reading is being done. This is used to label jobs '
               'on aws batch for monitoring and accounting purposes.')
     )
-    aws_read_parser.add_argument(
-        '-B', '--batch-batch',
-        default=None,
-        type=int,
-        help="Specify the size of batches within each batch instance."
-    )
     subparsers = parser.add_subparsers(title='Method')
     subparsers.required = True
     subparsers.dest = 'method'
@@ -425,8 +422,7 @@ def main():
         bulk_manager = BulkAwsReadingManager(readers,
                                              buffer_days=args.buffer,
                                              project_name=args.project_name,
-                                             only_unread=args.only_unread,
-                                             batch_batch=args.batch_batch)
+                                             only_unread=args.only_unread)
     else:
         assert False, "This shouldn't be allowed."
 

--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -208,7 +208,7 @@ class BulkAwsReadingManager(BulkReadingManager):
     }
 
     batch_batch = {
-        'mti': 10
+        'mti': 100
     }
 
     def __init__(self, *args, **kwargs):

--- a/indra_db/reading/read_db_aws.py
+++ b/indra_db/reading/read_db_aws.py
@@ -13,6 +13,7 @@ import logging
 import random
 from argparse import ArgumentParser
 
+from indra.util import batch_iter
 from indra_reading.readers import get_reader_classes
 from indra_reading.util import get_s3_job_log_prefix
 
@@ -92,6 +93,11 @@ def get_parser():
         action='store_true',
         help="Use the test database."
     )
+    parser.add_argument(
+        '-b', '--batch',
+        default=None,
+        help="Select the size of batches for the content to be read."
+    )
     return parser
 
 
@@ -163,8 +169,13 @@ def main():
         db = None
 
     # Read everything ========================================
-    run_reading(readers, tcids, verbose=True, db=db,
-                reading_mode=args.read_mode, rslt_mode=args.rslt_mode)
+    if args.batch is None:
+        run_reading(readers, tcids, verbose=True, db=db,
+                    reading_mode=args.read_mode, rslt_mode=args.rslt_mode)
+    else:
+        for tcid_batch in batch_iter(tcids, args.batch):
+            run_reading(readers, tcid_batch, verbose=True, db=db,
+                        reading_mode=args.read_mode, rslt_mode=args.rslt_mode)
 
     # Preserve the sparser logs
     contents = os.listdir('.')

--- a/indra_db/reading/submit_reading_pipeline.py
+++ b/indra_db/reading/submit_reading_pipeline.py
@@ -67,6 +67,7 @@ class DbReadingSubmitter(ReadingSubmitter):
         super(DbReadingSubmitter, self).__init__(*args, **kwargs)
         self.s3_prefix = get_s3_log_prefix(self.s3_base)
         self.time_tag = datetime.now().strftime('%Y%m%d_%H%M')
+        self.batch_batch = kwargs.pop('batch_batch', None)
         self.run_record = {}
         self.start_time = None
         self.end_time = None
@@ -85,6 +86,8 @@ class DbReadingSubmitter(ReadingSubmitter):
                 self.job_base, job_name, self.s3_base]
         base += ['/sw/tmp', read_mode, rslt_mode, '32', str(start_ix),
                  str(end_ix)]
+        if self.batch_batch is not None:
+            base += ['-b', self.batch_batch]
         return base
 
     def _get_extensions(self):


### PR DESCRIPTION
This should allow MTI to run in batches, generally reducing the likelihood of apparent hangups and job log-stall timeouts.