### PR TITLE
Deprecate get_primary_db

### DIFF
--- a/indra_db/client/datasets.py
+++ b/indra_db/client/datasets.py
@@ -3,7 +3,7 @@ from itertools import permutations
 from sqlalchemy import or_
 
 from indra.databases import hgnc_client
-from indra_db.util import get_primary_db, get_statement_object
+from indra_db.util import get_db, get_statement_object
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ def get_statement_essentials(clauses, count=1000, db=None, preassembled=True):
         `(uuid, sid, hash, type, (agent_1, agent_2, ...))`.
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     stmts_tblname = 'pa_statements' if preassembled else 'raw_statements'
 

--- a/indra_db/client/principal/curation.py
+++ b/indra_db/client/principal/curation.py
@@ -7,7 +7,7 @@ from collections import Counter
 
 from sqlalchemy.exc import IntegrityError
 
-from indra_db.util import get_primary_db
+from indra_db import get_db
 from indra_db.exceptions import BadHashError
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ def submit_curation(hash_val, tag, curator, ip, text=None,
         A database manager object used to access the database.
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     inp = {'tag': tag, 'text': text, 'curator': curator, 'ip': ip,
            'source': source, 'pa_hash': hash_val, 'source_hash': ev_hash}
@@ -69,7 +69,7 @@ def submit_curation(hash_val, tag, curator, ip, text=None,
 def get_curations(db=None, **params):
     """Get all curations for a certain level given certain criteria."""
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     cur = db.Curation
 
     constraints = []
@@ -152,7 +152,7 @@ def get_curator_counts(db=None):
         submitted.
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     res = db.select_all(db.Curation)
     curators = [r.curator for r in res]
     counter = Counter(curators)

--- a/indra_db/client/principal/raw_statements.py
+++ b/indra_db/client/principal/raw_statements.py
@@ -8,7 +8,7 @@ from sqlalchemy import intersect_all
 
 from indra.util import clockit
 
-from indra_db import get_primary_db
+from indra_db import get_db
 from indra_db.util import regularize_agent_id
 
 # ====
@@ -39,7 +39,7 @@ def get_raw_stmt_jsons_from_papers(id_list, id_type='pmid', db=None):
         not be included in the dict.
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     # Get the attribute for this id type.
     if id_type == 'pmid':
@@ -85,7 +85,7 @@ def get_direct_raw_stmt_jsons_from_agents(agents=None, stmt_type=None, db=None,
                                           max_stmts=None, offset=None):
     """Get Raw statement jsons from a list of agent refs and Statement type."""
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     # Turn the agents parameters into an intersection of queries for stmt ids.
     entity_queries = []

--- a/indra_db/client/statements.py
+++ b/indra_db/client/statements.py
@@ -15,7 +15,7 @@ from indra.databases import hgnc_client
 from indra.util import batch_iter, clockit
 from indra.statements import Unresolved, Evidence, Statement
 
-from indra_db.util import get_primary_db, get_raw_stmts_frm_db_list, \
+from indra_db.util import get_db, get_raw_stmts_frm_db_list, \
     get_statement_object
 
 
@@ -249,7 +249,7 @@ def get_statements(clauses, count=1000, do_stmt_count=False, db=None,
                   DeprecationWarning)
     cnt = count
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     stmts_tblname = 'pa_statements' if preassembled else 'raw_statements'
 
@@ -394,7 +394,7 @@ def get_evidence(pa_stmt_list, db=None, fix_refs=True, use_views=True):
                    'but some results may be subtly different.'),
                   DeprecationWarning)
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     # Turn the list into a dict.
     stmt_dict = {s.get_hash(shallow=True): s for s in pa_stmt_list}
@@ -506,7 +506,7 @@ def get_support(statements, db=None, recursive=False):
                   DeprecationWarning)
     # TODO: Allow recursive mode (argument should probably be an integer level)
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     if not isinstance(statements, dict):
         stmt_dict = {s.get_hash(shallow=True): s for s in statements}

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -167,7 +167,7 @@ class DatabaseManager(object):
     large data transfers.
 
     If you wish to access the primary database, you can simply use the
-    `get_primary_db` to get an instance of this object using the default
+    `get_db` function to get an instance of this object using the default
     settings.
 
     Parameters
@@ -176,15 +176,15 @@ class DatabaseManager(object):
         The database to which you want to interface.
     label : OPTIONAL[str]
         A short string to indicate the purpose of the db instance. Set as
-        primary when initialized be `get_primary_db` or `get_db`.
+        `db_label` when initialized with `get_db(db_label)`.
 
     Example
     -------
     If you wish to acces the primary database and find the the metadata for a
     particular pmid, 1234567:
 
-    >> from indra.db import get_primary_db()
-    >> db = get_primary_db()
+    >> from indra.db import get_db
+    >> db = get_db('primary')
     >> res = db.select_all(db.TextRef, db.TextRef.pmid == '1234567')
 
     You will get a list of objects whose attributes give the metadata contained

--- a/indra_db/managers/content_manager.py
+++ b/indra_db/managers/content_manager.py
@@ -24,7 +24,7 @@ from indra.literature import pubmed_client
 from indra.literature.pmc_client import id_lookup
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
-from indra_db.util import get_primary_db, get_db
+from indra_db.util import get_db
 from indra_db.databases import texttypes, formats
 from indra_db.databases import sql_expressions as sql_exp
 from indra_db.util.data_gatherer import DataGatherer, DGContext
@@ -1667,8 +1667,6 @@ def _main():
             db = get_temp_db()
         else:
             db = get_db(args.database)
-    elif args.database == 'primary':
-        db = get_primary_db()
     else:
         db = get_db(args.database)
 

--- a/indra_db/managers/reading_manager.py
+++ b/indra_db/managers/reading_manager.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 from indra_reading.readers import get_reader_class
 
 from indra_db.reading import read_db as rdb
-from indra_db.util import get_primary_db, get_db
+from indra_db.util import get_db
 from indra_db.reading.submit_reading_pipeline import DbReadingSubmitter
 
 logger = logging.getLogger(__name__)
@@ -414,8 +414,6 @@ def main():
             db = get_temp_db()
         else:
             db = get_db(args.database)
-    elif args.database == 'primary':
-        db = get_primary_db()
     else:
         db = get_db(args.database)
 

--- a/indra_db/reading/read_db.py
+++ b/indra_db/reading/read_db.py
@@ -22,7 +22,7 @@ from indra_reading.readers import ReadingData, get_reader, Content,\
 from indra_reading.readers.util import get_dir
 from indra.util import zip_string
 
-from indra_db import get_primary_db, formats
+from indra_db import get_db, formats
 from indra_db.databases import readers, reader_versions
 from indra_db.util.data_gatherer import DataGatherer, DGContext
 from indra_db.util import insert_raw_agents, unpack
@@ -248,7 +248,7 @@ class DatabaseReader(object):
         yielded by the database at a given time.
     db : indra_db.DatabaseManager instance
         Optional, default is None, in which case the primary database provided
-        by `get_primary_db` function is used. Used to interface with a
+        by `get_db('primary')` function is used. Used to interface with a
         different database.
     """
     def __init__(self, tcids, reader, verbose=True, reading_mode='unread',
@@ -262,7 +262,7 @@ class DatabaseReader(object):
         self.batch_size = batch_size
         self.n_proc = n_proc
         if db is None:
-            self._db = get_primary_db()
+            self._db = get_db('primary')
         else:
             self._db = db
         self._tc_rd_link = \

--- a/indra_db/stats.py
+++ b/indra_db/stats.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import boto3
 from sqlalchemy import func
 
-from indra_db.util import get_primary_db
+from indra_db.util import get_db
 
 
 def __report_stat(report_str, fname=None, do_print=True):
@@ -37,7 +37,7 @@ def _report_groups(db, count_obj, group_obj, fname, *filters):
 
 def get_text_ref_stats(fname=None, db=None):
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     tc_rdng_link = db.TextContent.id == db.Reading.text_content_id
     __report_stat("Text ref statistics:", fname)
     __report_stat("--------------------", fname)
@@ -61,7 +61,7 @@ def get_text_ref_stats(fname=None, db=None):
 
 def get_text_content_stats(fname=None, db=None):
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     tc_rdng_link = db.TextContent.id == db.Reading.text_content_id
     __report_stat("\nText Content statistics:", fname)
     __report_stat('------------------------', fname)
@@ -93,7 +93,7 @@ def get_text_content_stats(fname=None, db=None):
 
 def get_readings_stats(fname=None, db=None):
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     __report_stat('\nReading statistics:', fname)
     __report_stat('-------------------', fname)
@@ -121,7 +121,7 @@ def get_readings_stats(fname=None, db=None):
 
 def get_statements_stats(fname=None, db=None, indra_version=None):
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     tc_rdng_link = db.TextContent.id == db.Reading.text_content_id
     stmt_rdng_link = db.Reading.id == db.RawStatements.reader_ref
 
@@ -156,7 +156,7 @@ def get_statements_stats(fname=None, db=None, indra_version=None):
 
 def get_pa_statement_stats(fname=None, db=None):
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     __report_stat('\nStatement Statistics:', fname)
     __report_stat('---------------------', fname)
     stmt_q = db.filter_query(db.PAStatements)
@@ -178,7 +178,7 @@ def get_pa_statement_stats(fname=None, db=None):
 def get_db_statistics(fname=None, db=None, tables=None):
     """Get statistics on the contents of the database"""
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     task_dict = {
         'text_ref': get_text_ref_stats,

--- a/indra_db/util/constructors.py
+++ b/indra_db/util/constructors.py
@@ -53,6 +53,7 @@ def get_primary_db(force_new=False):
         An instance of the database manager that is attached to the primary
         database.
     """
+    logger.warning("DEPRECATION WARNING: This function is being deprecated.")
     defaults = get_databases()
     if 'primary' in defaults.keys():
         primary_host = defaults['primary']

--- a/indra_db/util/content_scripts.py
+++ b/indra_db/util/content_scripts.py
@@ -4,7 +4,7 @@ from sqlalchemy import text
 from functools import lru_cache
 from collections import defaultdict
 
-from .constructors import get_primary_db
+from .constructors import get_db
 from .helpers import unpack, _get_trids
 
 
@@ -36,7 +36,7 @@ def get_stmts_with_agent_text_like(pattern, filter_genes=False,
         in its db_refs
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     # Query Raw agents table for agents with TEXT db_ref matching pattern
     # Selects agent texts, statement ids and agent numbers. The agent number
@@ -90,7 +90,7 @@ def get_stmts_with_agent_text_in(agent_texts, filter_genes=False, db=None):
         containing an agent with that TEXT in its db_refs.
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
 
     # Query Raw agents table for agents with TEXT db_ref matching pattern
     # Selects agent texts, statement ids and agent numbers. The agent number
@@ -151,7 +151,7 @@ def get_text_content_from_stmt_ids(stmt_ids, db=None):
         fulltext xml > plaintext abstract > title
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     identifiers = get_content_identifiers_from_stmt_ids(stmt_ids)
     content = _get_text_content(identifiers.values())
     return identifiers, content
@@ -186,7 +186,7 @@ def get_text_content_from_pmids(pmids, db=None):
         to the best available text content.
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     identifiers = get_content_identifiers_from_pmids(pmids)
     content = _get_text_content(identifiers.values())
     return identifiers, content
@@ -216,7 +216,7 @@ def get_content_identifiers_from_stmt_ids(stmt_ids, db=None):
         (these typically come from databases)
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     stmt_ids = tuple(set(stmt_ids))
     query = """SELECT
                    sub.stmt_id, tc.text_ref_id, tc.source,
@@ -266,7 +266,7 @@ def get_content_identifiers_from_pmids(pmids, db=None):
         fulltext xml > plaintext abstract > title
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     pmids = tuple(set(pmids))
     query = """SELECT
                    tr.pmid, tr.id, tc.source, tc.format, tc.text_type
@@ -326,7 +326,7 @@ def _get_text_content(content_identifiers, db=None):
         exists in the database are excluded as keys.
     """
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
     # Remove duplicate identifiers
     content_identifiers = set(content_identifiers)
     # Query finds content associated to each identifier by joining
@@ -392,7 +392,7 @@ def get_text_content_from_text_refs(text_refs, db=None, use_cache=True):
     """
     primary = False
     if db is None:
-        db = get_primary_db()
+        db = get_db('primary')
         primary = True
     if primary and use_cache:
         frozen_text_refs = frozenset(text_refs.items())
@@ -408,7 +408,7 @@ def get_text_content_from_text_refs(text_refs, db=None, use_cache=True):
 
 @lru_cache(10000)
 def _get_text_content_from_text_refs_cached(frozen_text_refs):
-    db = get_primary_db()
+    db = get_db('primary')
     text_refs = dict(frozen_text_refs)
     text_ref_id = _get_text_ref_id_from_text_refs(text_refs, db)
     if text_ref_id is None:


### PR DESCRIPTION
Deprecate the `get_primary_db` function used for constructing handles to the database. Leave the function in place but with a deprecation warning, and replace all internal usages. This should solve several upstream issues with generating bad state when a session fails.