### PR TITLE
Add statement validation to knowledgebase manager

### DIFF
--- a/indra_db/client/principal/content.py
+++ b/indra_db/client/principal/content.py
@@ -53,7 +53,7 @@ def get_reader_output(db, ref_id, ref_type='tcid', reader=None,
     reading_dict = defaultdict(lambda: defaultdict(lambda: []))
     for tcid, reader, result in res:
         unpacked_result = None
-        if len(result) == 0:
+        if not result:
             logger.warning("Got reading result with zero content.")
         else:
             unpacked_result = unpack(result)

--- a/indra_db/managers/knowledgebase_manager.py
+++ b/indra_db/managers/knowledgebase_manager.py
@@ -11,7 +11,7 @@ import pickle
 import logging
 import tempfile
 from collections import defaultdict
-
+from indra.statements.validate import assert_valid_statement
 from indra_db.util import insert_db_stmts
 from indra_db.util.distill_statements import extract_duplicates, KeyFunc
 
@@ -28,6 +28,10 @@ class KnowledgebaseManager(object):
         """Upload the content for this dataset into the database."""
         dbid = self._check_reference(db)
         stmts = self._get_statements()
+        # Raise any validity issues with statements as exceptions here
+        # to avoid uploading invalid content.
+        for stmt in stmts:
+            assert_valid_statement(stmt)
         insert_db_stmts(db, stmts, dbid)
         return
 


### PR DESCRIPTION
This PR brings in statement validation from INDRA to block any knowledge base upload with invalid statements. It also makes a small change in reader output queries, where result can be None and has to be handled.