### PR TITLE
Tidy miscellaneous odds and ends

### DIFF
--- a/after_zappa
+++ b/after_zappa
@@ -10,7 +10,7 @@ from indra_db.util.aws import get_role_kwargs
 
 # Lambda CONFIG parameters
 aws_role = CONFIG['lambda']['role']
-aws_primary_function = CONFIG['lambda']['function']
+aws_primary_function = 'indra-db-api-ROOT'
 
 # Load the Zappa config file.
 ZAPPA_CONFIG = 'zappa_settings.json'

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -73,11 +73,8 @@ env = Environment(loader=ChoiceLoader([app.jinja_loader, auth.jinja_loader,
 def url_for(*args, **kwargs):
     res = base_url_for(*args, **kwargs)
     if DEPLOYMENT is not None:
-        logger.info(f'URL_FOR input: {args}, {kwargs}')
         if not res.startswith(f'/{DEPLOYMENT}'):
-            logger.info(f'pre: {res}')
             res = f'/{DEPLOYMENT}' + res
-        logger.info(f'final: {res}')
     return res
 
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -236,6 +236,9 @@ def old_search():
 @user_log_endpoint
 def get_statements(result_type, method):
     """Get some statements constrained by query."""
+    if result_type not in ApiCall.valid_result_types:
+        return Response('Page not found.', 404)
+
     note_in_log(method=method, result_type=result_type)
     note_in_log(db_host=get_ro_host('primary'))
 

--- a/rest_api/api.py
+++ b/rest_api/api.py
@@ -122,12 +122,18 @@ def ground():
 def search():
     stmt_types = {c.__name__ for c in get_all_descendants(Statement)}
     stmt_types -= {'Influence', 'Event', 'Unresolved'}
+    stmt_types_json = json.dumps(sorted(list(stmt_types)))
     source_info, source_colors = get_html_source_info()
-    return render_my_template('search.html', 'Search',
-                              source_colors=source_colors,
-                              source_info=source_info,
-                              search_active=True,
-                              stmt_types_json=json.dumps(sorted(list(stmt_types))))
+    if TESTING['status']:
+        vue_src = url_for("serve_indralab_vue", file='IndralabVue.umd.js')
+        vue_style = url_for("serve_indralab_vue", file='IndralabVue.css')
+    else:
+        vue_src = f'{VUE_ROOT}/IndralabVue.umd.js'
+        vue_style = f'{VUE_ROOT}/IndralabVue.css'
+    return render_my_template(
+        'search.html', 'Search', source_colors=source_colors,
+        source_info=source_info, search_active=True, vue_src=vue_src,
+        vue_style=vue_style, stmt_types_json=stmt_types_json)
 
 
 @app.route('/data-vis/<path:file_path>')
@@ -146,6 +152,26 @@ def serve_data_vis(file_path):
     with open(full_path, 'rb') as f:
         return Response(f.read(),
                         content_type=ct)
+
+
+if TESTING['status']:
+    assert path.exists(VUE_ROOT), "Cannot test API with Vue packages."
+
+    @app.route('/ilv/<path:file>')
+    def serve_indralab_vue(file):
+        full_path = path.join(HERE, VUE_ROOT, file)
+        if not path.exists(full_path):
+            return abort(404)
+        ext = full_path.split('.')[-1]
+        if ext == 'js':
+            ct = 'application/javascript'
+        elif ext == 'css':
+            ct = 'text/css'
+        else:
+            ct = None
+        with open(full_path, 'rb') as f:
+            return Response(f.read(),
+                            content_type=ct)
 
 
 @app.route('/monitor')

--- a/rest_api/call_handlers.py
+++ b/rest_api/call_handlers.py
@@ -75,6 +75,8 @@ class ApiCall:
         self.special = {}
         return
 
+    valid_result_types = ['statements', 'interactions', 'agents', 'hashes']
+
     def run(self, result_type):
 
         # Get the db query object.

--- a/rest_api/config.py
+++ b/rest_api/config.py
@@ -4,6 +4,9 @@ from flask_jwt_extended import jwt_optional
 TITLE = "The INDRA Database"
 DEPLOYMENT = environ.get('INDRA_DB_API_DEPLOYMENT')
 VUE_ROOT = environ.get('INDRA_DB_API_VUE_ROOT')
+if VUE_ROOT is not None and VUE_ROOT.endswith('/'):
+    # Peal off the trailing slash.
+    VUE_ROOT = VUE_ROOT[:-1]
 MAX_STMTS = int(0.5e3)
 REDACT_MESSAGE = '[MISSING/INVALID CREDENTIALS: limited to 200 char for Elsevier]'
 

--- a/rest_api/config.py
+++ b/rest_api/config.py
@@ -3,7 +3,7 @@ from flask_jwt_extended import jwt_optional
 
 TITLE = "The INDRA Database"
 DEPLOYMENT = environ.get('INDRA_DB_API_DEPLOYMENT')
-VUE_ROOT = environ.get('INDRA_DB_API_VUE')
+VUE_ROOT = environ.get('INDRA_DB_API_VUE_ROOT')
 MAX_STMTS = int(0.5e3)
 REDACT_MESSAGE = '[MISSING/INVALID CREDENTIALS: limited to 200 char for Elsevier]'
 

--- a/rest_api/config.py
+++ b/rest_api/config.py
@@ -3,6 +3,7 @@ from flask_jwt_extended import jwt_optional
 
 TITLE = "The INDRA Database"
 DEPLOYMENT = environ.get('INDRA_DB_API_DEPLOYMENT')
+VUE_ROOT = environ.get('INDRA_DB_API_VUE')
 MAX_STMTS = int(0.5e3)
 REDACT_MESSAGE = '[MISSING/INVALID CREDENTIALS: limited to 200 char for Elsevier]'
 

--- a/rest_api/static/curationFunctions.js
+++ b/rest_api/static/curationFunctions.js
@@ -86,7 +86,7 @@ function submitButtonClick(clickEvent) {
     // source_hash == ev['source_hash'] == pmid_row.id; "evidence level"
     const source_hash = pmid_row.dataset.source_hash;
     // stmt_hash == hash == stmt_info['hash'] == table ID; "(pa-) statement level"
-    const stmt_hash = pmid_row.parentElement.dataset.stmt_hash;
+    const stmt_hash = pmid_row.parentElement.parentElement.dataset.stmt_hash;
 
     // CURATION DICT
     // example: curation_dict = {'tag': 'Reading', 'text': '"3200 A" is picked up as an agent.', 'curator': 'Klas', 'ev_hash': ev_hash};

--- a/rest_api/templates/search.html
+++ b/rest_api/templates/search.html
@@ -4,8 +4,8 @@
 {{ super() }}
 
 <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-<script src="{{ url_for('serve_indralab_vue', file='IndralabVue.umd.js') }}"></script>
-<link href="{{  url_for('serve_indralab_vue', file='IndralabVue.css') }}" rel="stylesheet">
+<script src="{{ vue_src }}"></script>
+<link href="{{  vue_style }}" rel="stylesheet">
 
 <style>
   {% for category, data in source_colors %}


### PR DESCRIPTION
- Fix curation submission in old form
- Change the root lambda endpoint in `after_zappa`
- Put an end to the cut-and-paste vue testing strategy (or rather formalize it)
- Remove some logging from `url_for`.