### PR TITLE
Add termcolor to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def main():
           include_package_data=True,
           install_requires=['indra', 'boto3', 'sqlalchemy', 'psycopg2-binary',
                             'pgcopy', 'matplotlib', 'flask', 'nltk',
-                            'reportlab', 'cachetools'],
+                            'reportlab', 'cachetools', 'termcolor'],
           extras_require={'test': ['nose', 'coverage', 'python-coveralls',
                                    'nose-timer']},
           )


### PR DESCRIPTION
This PR adds a missing requirement to setup since it's required by downstream dependencies, see e.g., https://travis-ci.com/github/indralab/emmaa/builds/203149488.