### PR TITLE
Fix condition in checking for trid_list

### DIFF
--- a/indra_db/client/principal/content.py
+++ b/indra_db/client/principal/content.py
@@ -98,7 +98,7 @@ def get_content_by_refs(db, pmid_list=None, trid_list=None, sources=None,
         the corresponding content.
     """
     # Make sure we only get one type of list.
-    if not pmid_list or trid_list:
+    if not (pmid_list or trid_list):
         raise ValueError("One of `pmid_list` or `trid_list` must be defined.")
     if pmid_list and trid_list:
         raise ValueError("Only one of `pmid_list` or `trid_list` may be used.")


### PR DESCRIPTION
I tried `get_content_by_refs` to fetch some text content and ran into and issue with passing only a `trid_list` that this PR fixes. But then found that this function doesn't return for a really long time (maybe deprecated?) so as an alternative, I'm using `TextContentSessionHandler.get_text_content_from_text_refs`, which seems to work well.