### PR TITLE
Skip supplementary MeSH concepts

### DIFF
--- a/indra_db/managers/content_manager.py
+++ b/indra_db/managers/content_manager.py
@@ -826,6 +826,11 @@ class Pubmed(_NihManager):
         copy_rows = []
         for pmid, annotation_list in self.annotations.items():
             for annotation in annotation_list:
+                # If supplementary IDs (they start with C and their int-ified
+                # values can overlap with main terms that start with D) are
+                # supported, this condition can be removed
+                if annotation.get('type') == 'supplementary':
+                    continue
                 # Format the row.
                 copy_row = (int(pmid), int(annotation['mesh'][1:]),
                             annotation['major_topic'])

--- a/indra_db/managers/content_manager.py
+++ b/indra_db/managers/content_manager.py
@@ -826,14 +826,13 @@ class Pubmed(_NihManager):
         copy_rows = []
         for pmid, annotation_list in self.annotations.items():
             for annotation in annotation_list:
-                # If supplementary IDs (they start with C and their int-ified
-                # values can overlap with main terms that start with D) are
-                # supported, this condition can be removed
-                if annotation.get('type') == 'supplementary':
-                    continue
+                # Handle it if supplementary IDs (they start with C and their
+                # intified values can overlap with main terms that start with D)
+                is_concept = annotation.get('type') == 'supplementary'
+
                 # Format the row.
                 copy_row = (int(pmid), int(annotation['mesh'][1:]),
-                            annotation['major_topic'])
+                            annotation['major_topic'], is_concept)
 
                 # Handle the qualifier
                 qual = annotation['qualifier']
@@ -846,7 +845,8 @@ class Pubmed(_NihManager):
 
         # Copy the results into the database
         self.copy_into_db(db, 'mesh_ref_annotations', copy_rows,
-                          ('pmid_num', 'mesh_num', 'major_topic', 'qual_num'))
+                          ('pmid_num', 'mesh_num', 'major_topic','is_concept',
+                           'qual_num'))
         return True
 
     def load_files_and_annotations(self, db, *args, **kwargs):

--- a/indra_db/managers/content_manager.py
+++ b/indra_db/managers/content_manager.py
@@ -835,11 +835,9 @@ class Pubmed(_NihManager):
                             annotation['major_topic'], is_concept)
 
                 # Handle the qualifier
-                qual = annotation['qualifier']
-                if qual is None:
-                    copy_row += (None,)
-                else:
-                    copy_row += (int(qual['mesh'][1:]),)
+                qualifiers = annotation['qualifiers']
+                qual = int(qualifiers[0]['mesh'][1:]) if qualifiers else None
+                copy_row += (qual,)
 
                 copy_rows.append(copy_row)
 


### PR DESCRIPTION
This is for compatibility with https://github.com/sorgerlab/indra/pull/1215 which adds support for extracting supplementary MeSH concepts from Medline XML.