### PR TITLE
Stmt dump to sif

### DIFF
--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -12,7 +12,7 @@ from indra_db.belief import get_belief
 from indra_db.config import CONFIG, get_s3_dump, record_in_test
 from indra_db.util import get_db, get_ro, S3Path
 from indra_db.util.aws import get_role_kwargs
-from indra_db.util.dump_sif import dump_sif_from_stmts, get_source_counts
+from indra_db.util.dump_sif import dump_sif, get_source_counts
 
 
 logger = logging.getLogger(__name__)
@@ -253,13 +253,9 @@ class Sif(Dumper):
         super(Sif, self).__init__(use_principal=use_principal, **kwargs)
 
     def dump(self, continuing=False):
-        latest_full_pa = get_latest_dump_s3_path(FullPaStmts.name)
-        if latest_full_pa:
-            s3 = boto3.client('s3')
-            s3_res = latest_full_pa.get(s3)
-            pa_stmts_list = pickle.loads(s3_res['Body'].read())
-            s3_outpath = self.get_s3_path()
-            dump_sif_from_stmts(stmt_list=pa_stmts_list, output=s3_outpath)
+        s3_path = self.get_s3_path()
+        srcc = SourceCount(ro=self.db)
+        dump_sif(s3_path, src_count_file=srcc.get_s3_path(), ro=self.db)
 
 
 class Belief(Dumper):

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -256,7 +256,8 @@ class Sif(Dumper):
         latest_full_pa = get_latest_dump_s3_path(FullPaStmts.name)
         if latest_full_pa:
             s3 = boto3.client('s3')
-            pa_stmts_list = latest_full_pa.get(s3)
+            s3_res = latest_full_pa.get(s3)
+            pa_stmts_list = pickle.loads(s3_res['Body'].read())
             s3_outpath = self.get_s3_path()
             dump_sif_from_stmts(stmt_list=pa_stmts_list, output=s3_outpath)
 

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -441,13 +441,6 @@ def dump(principal_db, readonly_db, delete_existing=False, allow_continue=True,
         else:
             logger.info("Readonly dump exists, skipping.")
 
-        if not allow_continue or not Sif.from_list(starter.manifest):
-            logger.info("Dumping sif from the readonly schema on principal.")
-            Sif(db=principal_db, date_stamp=starter.date_stamp)\
-                .dump(continuing=allow_continue)
-        else:
-            logger.info("Sif dump exists, skipping.")
-
         if not allow_continue \
                 or not FullPaStmts.from_list(starter.manifest):
             logger.info("Dumping all PA Statements as a pickle.")
@@ -456,6 +449,13 @@ def dump(principal_db, readonly_db, delete_existing=False, allow_continue=True,
                 .dump(continuing=allow_continue)
         else:
             logger.info("Statement dump exists, skipping.")
+
+        if not allow_continue or not Sif.from_list(starter.manifest):
+            logger.info("Dumping sif from the readonly schema on principal.")
+            Sif(db=principal_db, date_stamp=starter.date_stamp)\
+                .dump(continuing=allow_continue)
+        else:
+            logger.info("Sif dump exists, skipping.")
 
         if not allow_continue \
                 or not StatementHashMeshId.from_list(starter.manifest):

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -12,7 +12,7 @@ from indra_db.belief import get_belief
 from indra_db.config import CONFIG, get_s3_dump, record_in_test
 from indra_db.util import get_db, get_ro, S3Path
 from indra_db.util.aws import get_role_kwargs
-from indra_db.util.dump_sif import dump_sif, get_source_counts
+from indra_db.util.dump_sif import dump_sif_from_stmts, get_source_counts
 
 
 logger = logging.getLogger(__name__)
@@ -247,19 +247,18 @@ class End(Dumper):
 class Sif(Dumper):
     name = 'sif'
     fmt = 'pkl'
-    db_required = True
-    db_options = ['principal', 'readonly']
+    db_required = False
 
     def __init__(self, use_principal=False, **kwargs):
         super(Sif, self).__init__(use_principal=use_principal, **kwargs)
 
-    def dump(self, continuing=False, include_src_counts=True):
-        s3_path = self.get_s3_path()
-        if include_src_counts:
-            srcc = SourceCount(ro=self.db)
-            dump_sif(s3_path, src_count_file=srcc.get_s3_path(), ro=self.db)
-        else:
-            dump_sif(s3_path, ro=self.db)
+    def dump(self, continuing=False):
+        latest_full_pa = get_latest_dump_s3_path(FullPaStmts.name)
+        if latest_full_pa:
+            s3 = boto3.client('s3')
+            pa_stmts_list = latest_full_pa.get(s3)
+            s3_outpath = self.get_s3_path()
+            dump_sif_from_stmts(stmt_list=pa_stmts_list, output=s3_outpath)
 
 
 class Belief(Dumper):

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -289,7 +289,7 @@ class SourceCount(Dumper):
 
 class FullPaJson(Dumper):
     name = 'full_pa_json'
-    fmt = 'json'
+    fmt = 'jsonl'
     db_required = True
     db_options = ['principal', 'readonly']
 
@@ -298,9 +298,9 @@ class FullPaJson(Dumper):
 
     def dump(self, continuing=False):
         query_res = self.db.session.query(self.db.FastRawPaLink.pa_json.distinct())
-        json_list = [json.loads(js[0]) for js in query_res.all()]
+        jsonl_str = '\n'.join([js[0] for js in query_res.all()])
         s3 = boto3.client('s3')
-        self.get_s3_path().upload(s3, json.dumps(json_list).encode('utf-8'))
+        self.get_s3_path().upload(s3, jsonl_str.encode('utf-8'))
 
 
 class FullPaStmts(Dumper):

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -389,7 +389,7 @@ def dump_sif(df_file=None, db_res_file=None, csv_file=None,
     df_file : Optional[Union[str, S3Path]]
         If provided, dump the sif to this location. Can be local file path, an
         s3 url string or an S3Path instance.
-    src_count_file : str
+    src_count_file : Optional[Union[str, S3Path]]
         A location to dump the source count dict. Can be local file path, an
         s3 url string or an S3Path instance.
     db_res_file : Optional[Union[str, S3Path]]

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -108,9 +108,10 @@ def load_db_content(ns_list, pkl_filename=None, ro=None, reload=False):
 
 def load_res_pos(ro=None):
     """Return residue/position data keyed by hash"""
+    logger.info('Getting residue and position info')
     if ro is None:
         ro = get_ro('primary')
-    res = {}
+    res = {'residue': {}, 'position': {}}
     for stmt_type in get_all_descendants(Modification):
         stmt_name = stmt_type.__name__
         if stmt_name in ('Modification', 'AddModification',
@@ -122,10 +123,10 @@ def load_res_pos(ro=None):
                               ro.FastRawPaLink.type_num == type_num)
         for jsb, in query:
             js = json.loads(jsb)
-            if 'residue' in js or 'position' in js:
-                res[js['matches_hash']] = {'residue': js.get('residue'),
-                                           'position': js.get('position')}
-
+            if 'residue' in js:
+                res['residue'][js['matches_hash']] = js['residue']
+            if 'position' in js:
+                res['position'][js['matches_hash']] = js['position']
     return res
 
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -152,7 +152,25 @@ def get_source_counts(pkl_filename=None, ro=None):
     return ev
 
 
-def make_dataframe(reconvert, db_content, pkl_filename=None):
+def make_dataframe(reconvert, db_content, res_pos_dict, src_count_dict,
+                   pkl_filename=None):
+    """Load data in db_content into a pandas dataframe and dump it
+
+    Parameters
+    ----------
+    reconvert : bool
+    db_content : List[Tuple[
+    res_pos_dict : Dict[str, Dict[str, str]]
+    src_count_dict : Dict[str, Dict[str, int]]
+    pkl_filename : Optional[Union[str, S3Path]]
+
+    Returns
+    -------
+    pd.DataFrame
+        A pandas dataframe of pairwise agent interactions with statement
+        information for the interaction
+    """
+    # Todo fix the mess with which files are required and which ones are not
     if isinstance(pkl_filename, str) and pkl_filename.startswith('s3:'):
         pkl_filename = S3Path.from_string(pkl_filename)
     if reconvert:
@@ -227,15 +245,19 @@ def make_dataframe(reconvert, db_content, pkl_filename=None):
             # Add all the pairs, and count up total evidence.
             for pair in pairs:
                 row = OrderedDict([
-                        ('agA_ns', pair[0][0]),
-                        ('agA_id', pair[0][1]),
-                        ('agA_name', pair[0][2]),
-                        ('agB_ns', pair[1][0]),
-                        ('agB_id', pair[1][1]),
-                        ('agB_name', pair[1][2]),
-                        ('stmt_type', info_dict['type']),
-                        ('evidence_count', info_dict['ev_count']),
-                        ('stmt_hash', hash)])
+                    ('agA_ns', pair[0][0]),
+                    ('agA_id', pair[0][1]),
+                    ('agA_name', pair[0][2]),
+                    ('agB_ns', pair[1][0]),
+                    ('agB_id', pair[1][1]),
+                    ('agB_name', pair[1][2]),
+                    ('stmt_type', info_dict['type']),
+                    ('evidence_count', info_dict['ev_count']),
+                    ('stmt_hash', hash),
+                    ('residue', res_pos_dict['residue'].get(hash)),
+                    ('position', res_pos_dict['position'].get(hash)),
+                    ('source_count', src_count_dict.get(hash))
+                ])
                 rows.append(row)
         if nkey_errors:
             ef = 'key_errors.csv'

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -10,7 +10,7 @@ from itertools import permutations
 from collections import OrderedDict
 
 from indra.util.aws import get_s3_client
-from indra.assemblers.indranet.assembler import make_df
+from indra.assemblers.indranet import IndraNetAssembler
 from indra_db.schemas.readonly_schema import ro_type_map
 from indra.statements.agent import default_ns_order
 
@@ -300,7 +300,8 @@ def dump_sif_from_stmts(stmt_list, output):
     output : Union[str, S3Path]
         Where to save the output to. Can be local file path or an S3Path.
     """
-    df = make_df(stmt_list=stmt_list)
+    ia = IndraNetAssembler(statements=stmt_list)
+    df = ia.make_df()
     if isinstance(output, S3Path):
         s3 = get_s3_client(False)
         output.put(s3=s3, body=pickle.dumps(df))


### PR DESCRIPTION
This PR updates how the Sif dump is made.

Instead of calling the DB directly, the Sif dumper now makes use of the indranet assembler's `make_df` method and the FullPaStmt dump.

The dump order is switched so that the Sif dumper can query for the FullPaStmt dump.