### PR TITLE
Sif tweaks

### DIFF
--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -387,15 +387,16 @@ class DatabaseManager(object):
         if self.session is None or not self.session.is_active:
             logger.debug('Attempting to get session...')
             DBSession = sessionmaker(bind=self.__engine,
-                                     autoflush=self.__protected,
-                                     autocommit=self.__protected)
+                                     autoflush=not self.__protected,
+                                     autocommit=not self.__protected)
             logger.debug('Got session.')
             self.session = DBSession()
             if self.session is None:
                 raise IndraDbException("Failed to grab session.")
             if self.__protected:
-                self.session.flush = \
-                    lambda *a, **k: logger.error("Write not allowed!")
+                def no_flush(*a, **k):
+                    logger.error("Write not allowed!")
+                self.session.flush = no_flush
 
     def get_tables(self):
         """Get a list of available tables."""

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -349,7 +349,7 @@ class FullPaJson(Dumper):
 
     def dump(self, continuing=False):
         query_res = self.db.session.query(self.db.FastRawPaLink.pa_json.distinct())
-        jsonl_str = '\n'.join([js[0] for js in query_res.all()])
+        jsonl_str = '\n'.join([js.decode() for js, in query_res.all()])
         s3 = boto3.client('s3')
         self.get_s3_path().upload(s3, jsonl_str.encode('utf-8'))
 

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -33,6 +33,18 @@ def list_dumps(started=None, ended=None):
         NOT been started. If None, do not filter by start status.
     ended : Optional[bool]
         The same as `started`, but checking whether the dump is ended or not.
+
+    Returns
+    -------
+    list of S3Path objects
+        Each S3Path object contains the bucket and key prefix information for
+        a set of dump files, e.g.
+
+            [S3Path(bigmech, indra-db/dumps/2020-07-16/),
+             S3Path(bigmech, indra-db/dumps/2020-08-28/),
+             S3Path(bigmech, indra-db/dumps/2020-09-18/),
+             S3Path(bigmech, indra-db/dumps/2020-11-12/),
+             S3Path(bigmech, indra-db/dumps/2020-11-13/)]
     """
     # Get all the dump "directories".
     s3_base = get_s3_dump()
@@ -59,8 +71,16 @@ def list_dumps(started=None, ended=None):
 def get_latest_dump_s3_path(dumper_name):
     """Get the latest version of a dump file by the given name.
 
-    `dumper_name` is indexed using the standardized `name` class attribute of
-    the dumper object.
+    Searches dumps that have already been *started* and gets the full S3
+    file path for the latest version of the dump of that type (e.g. "sif",
+    "belief", "source_count", etc.)
+
+    Parameters
+    ----------
+    dumper_name : str
+        The standardized name for the dumper classes defined in this module,
+        defined in the `name` class attribute of the dumper object.
+        E.g., the standard dumper name "sif" can be obtained from ``Sif.name``.
     """
     # Get all the dumps that were properly started.
     s3 = boto3.client('s3')
@@ -534,7 +554,8 @@ def parse_args():
 
 
 if __name__ == '__main__':
+    # Collect args and run the top-level dump script
     args = parse_args()
     dump(get_db(args.database, protected=False),
-         get_ro(args.readonly, protected=False), args.delet_existing,
+         get_ro(args.readonly, protected=False), args.delete_existing,
          args.allow_continue, args.load_only, args.dump_only)

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -488,6 +488,16 @@ def dump(principal_db, readonly_db, delete_existing=False, allow_continue=True,
                                              date_stamp=starter.date_stamp)
             res_pos_dumper.dump(continuing=allow_continue)
             res_pos_dump = res_pos_dumper.get_s3_path()
+        else:
+            logger.info("Residue position dump exists, skipping")
+
+        src_count_dump = SourceCount.from_list(starter.manifest)
+        if not allow_continue or not src_count_dump:
+            logger.info("Dumping source count")
+            src_count_dumper = SourceCount(db=readonly_db,
+                                           date_stamp=starter.date_stamp)
+            src_count_dumper.dump(continuing=allow_continue)
+            src_count_dump = src_count_dumper.get_s3_path()
 
         dump_file = Readonly.from_list(starter.manifest)
         if not allow_continue or not dump_file:

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -332,6 +332,8 @@ class ResiduePosition(Dumper):
     def dump(self, continuing=False):
         res_pos_dict = load_res_pos(ro=self.db)
         s3 = boto3.client('s3')
+        logger.info(f'Uploading residue position dump to '
+                    f'{self.get_s3_path().to_string()}')
         self.get_s3_path().upload(s3=s3, body=pickle.dumps(res_pos_dict))
 
 

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -520,11 +520,9 @@ def dump(principal_db, readonly_db, delete_existing=False, allow_continue=True,
         else:
             logger.info("Sif dump exists, skipping.")
 
-        if not allow_continue \
-                or not FullPaStmts.from_list(starter.manifest):
-            logger.info("Dumping all PA Statements as a pickle.")
-            FullPaStmts(db=principal_db,
-                        date_stamp=starter.date_stamp)\
+        if not allow_continue or not FullPaJson.from_list(starter.manifest):
+            logger.info("Dumping all PA Statements as jsonl.")
+            FullPaJson(db=principal_db, date_stamp=starter.date_stamp)\
                 .dump(continuing=allow_continue)
         else:
             logger.info("Statement dump exists, skipping.")

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -484,7 +484,7 @@ def dump(principal_db, readonly_db, delete_existing=False, allow_continue=True,
         res_pos_dump = ResiduePosition.from_list(starter.manifest)
         if not allow_continue or not res_pos_dump:
             logger.info("Dumping residue and position")
-            res_pos_dumper = ResiduePosition(db=principal_db,
+            res_pos_dumper = ResiduePosition(db=readonly_db,
                                              date_stamp=starter.date_stamp)
             res_pos_dumper.dump(continuing=allow_continue)
             res_pos_dump = res_pos_dumper.get_s3_path()

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -336,7 +336,7 @@ class ResiduePosition(Dumper):
 
 class FullPaJson(Dumper):
     name = 'full_pa_json'
-    fmt = 'json'
+    fmt = 'jsonl'
     db_required = True
     db_options = ['principal', 'readonly']
 
@@ -345,9 +345,9 @@ class FullPaJson(Dumper):
 
     def dump(self, continuing=False):
         query_res = self.db.session.query(self.db.FastRawPaLink.pa_json.distinct())
-        json_list = [json.loads(js[0]) for js in query_res.all()]
+        jsonl_str = '\n'.join([js[0] for js in query_res.all()])
         s3 = boto3.client('s3')
-        self.get_s3_path().upload(s3, json.dumps(json_list).encode('utf-8'))
+        self.get_s3_path().upload(s3, jsonl_str.encode('utf-8'))
 
 
 class FullPaStmts(Dumper):

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -81,6 +81,10 @@ def get_latest_dump_s3_path(dumper_name):
         The standardized name for the dumper classes defined in this module,
         defined in the `name` class attribute of the dumper object.
         E.g., the standard dumper name "sif" can be obtained from ``Sif.name``.
+
+    Returns
+    -------
+    Union[S3Path, None]
     """
     # Get all the dumps that were properly started.
     s3 = boto3.client('s3')

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -323,7 +323,7 @@ class ResiduePosition(Dumper):
     name = 'res_pos'
     fmt = 'pkl'
     db_required = True
-    db_options = ['readonly']
+    db_options = ['readonly', 'principal']
 
     def __init__(self, use_principal=True, **kwargs):
         super(ResiduePosition, self).__init__(use_principal=use_principal,

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -285,6 +285,8 @@ class Sif(Dumper):
                  src_count_file=src_counts_path,
                  res_pos_file=res_pos_path,
                  belief_file=belief_path,
+                 reload=True,
+                 reconvert=True,
                  ro=self.db)
 
 

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -278,15 +278,13 @@ class Sif(Dumper):
     def __init__(self, use_principal=False, **kwargs):
         super(Sif, self).__init__(use_principal=use_principal, **kwargs)
 
-    def dump(self, continuing=False):
+    def dump(self, src_counts_path, res_pos_path, belief_path,
+             continuing=False):
         s3_path = self.get_s3_path()
-        src_counts = get_latest_dump_s3_path(SourceCount.name)
-        res_pos = get_latest_dump_s3_path(ResiduePosition.name)
-        belief = get_latest_dump_s3_path(Belief.name)
         dump_sif(df_file=s3_path,
-                 src_count_file=src_counts.get_s3_path(),
-                 res_pos_file=res_pos.get_s3_path(),
-                 belief_file=belief.get_s3_path(),
+                 src_count_file=src_counts_path,
+                 res_pos_file=res_pos_path,
+                 belief_file=belief_path,
                  ro=self.db)
 
 
@@ -513,7 +511,10 @@ def dump(principal_db, readonly_db, delete_existing=False, allow_continue=True,
         if not allow_continue or not Sif.from_list(starter.manifest):
             logger.info("Dumping sif from the readonly schema on principal.")
             Sif(db=principal_db, date_stamp=starter.date_stamp)\
-                .dump(continuing=allow_continue)
+                .dump(src_counts_path=src_count_dump,
+                      res_pos_path=res_pos_dump,
+                      belief_path=belief_dump,
+                      continuing=allow_continue)
         else:
             logger.info("Sif dump exists, skipping.")
 

--- a/indra_db/managers/dump_manager.py
+++ b/indra_db/managers/dump_manager.py
@@ -291,6 +291,7 @@ class Sif(Dumper):
 
 
 class Belief(Dumper):
+    """Dump a dict of belief scores keyed by hash"""
     name = 'belief'
     fmt = 'json'
     db_required = True
@@ -326,7 +327,7 @@ class ResiduePosition(Dumper):
 
     def __init__(self, use_principal=True, **kwargs):
         super(ResiduePosition, self).__init__(use_principal=use_principal,
-                                             **kwargs)
+                                              **kwargs)
 
     def dump(self, continuing=False):
         res_pos_dict = load_res_pos(ro=self.db)
@@ -335,6 +336,7 @@ class ResiduePosition(Dumper):
 
 
 class FullPaJson(Dumper):
+    """Dumps all statements found in FastRawPaLink as jsonl"""
     name = 'full_pa_json'
     fmt = 'jsonl'
     db_required = True
@@ -351,6 +353,7 @@ class FullPaJson(Dumper):
 
 
 class FullPaStmts(Dumper):
+    """Dumps all statements found in FastRawPaLink as a pickle"""
     name = 'full_pa_stmts'
     fmt = 'pkl'
     db_required = True

--- a/indra_db/schemas/readonly_schema.py
+++ b/indra_db/schemas/readonly_schema.py
@@ -636,6 +636,7 @@ def get_schema(Base):
         activity = Column(String)
         is_active = Column(Boolean)
         agent_count = Column(Integer)
+        is_complex_dup = Column(Boolean)
     ro_tables[TextMeta.__tablename__] = TextMeta
 
     class NameMeta(Base, NamespaceLookup):
@@ -657,6 +658,7 @@ def get_schema(Base):
         activity = Column(String)
         is_active = Column(Boolean)
         agent_count = Column(Integer)
+        is_complex_dup = Column(Boolean)
     ro_tables[NameMeta.__tablename__] = NameMeta
 
     class OtherMeta(Base, ReadonlyTable):

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -327,7 +327,7 @@ def make_dataframe(reconvert, db_content, res_pos_dict, src_count_dict,
                     ('residue', res_pos_dict['residue'].get(hash)),
                     ('position', res_pos_dict['position'].get(hash)),
                     ('source_count', src_count_dict.get(hash)),
-                    ('belief', belief_dict.get(hash))
+                    ('belief', belief_dict.get(str(hash)))
                 ])
                 rows.append(row)
         if nkey_errors:

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -180,6 +180,7 @@ def get_source_counts(pkl_filename=None, ro=None):
     The dictionary is at the top level keyed by statement hash and each
     entry contains a dictionary keyed by the source that support the
     statement where the entries are the evidence count for that source."""
+    logger.info('Getting source counts per statement')
     if isinstance(pkl_filename, str) and pkl_filename.startswith('s3:'):
         pkl_filename = S3Path.from_string(pkl_filename)
     if not ro:

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -63,6 +63,20 @@ def load_pickle_from_s3(s3_path):
         logger.exception(e)
 
 
+def load_json_from_s3(s3_path):
+    """Helper to load json from s3"""
+    logger.info(f'Loading json {s3_path} from s3.')
+    s3 = get_s3_client(False)
+    try:
+        res = s3_path.get(s3)
+        obj = json.loads(res['Body'].read().decode())
+        logger.info(f'Finished loading {s3_path}.')
+        return obj
+    except Exception as e:
+        logger.error(f'Failed to load {s3_path}.')
+        logger.exception(e)
+
+
 def load_db_content(ns_list, pkl_filename=None, ro=None, reload=False):
     """Get preassembled stmt metadata from the DB for export.
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -409,7 +409,7 @@ def get_parser():
 
 
 def dump_sif(src_count_file, res_pos_file, belief_file, df_file=None,
-             db_res_file=None, csv_file=None, reload=False, reconvert=True,
+             db_res_file=None, csv_file=None, reload=True, reconvert=True,
              ro=None):
     """Build and dump a sif dataframe of PA statements with grounded agents
 
@@ -436,7 +436,7 @@ def dump_sif(src_count_file, res_pos_file, belief_file, df_file=None,
     reconvert : bool
         Whether to generate a new DataFrame from the database content or
         to load and return a DataFrame from `df_file`. If False, `df_file`
-        must be given.
+        must be given. Default: True.
     reload : bool
         If True, load new content from the database and make a new
         dataframe. If False, content can be loaded from provided files.

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -138,9 +138,10 @@ def load_db_content(ns_list, pkl_filename=None, ro=None, reload=False):
 
 def load_res_pos(ro=None):
     """Return residue/position data keyed by hash"""
+    logger.info('Getting residue and position info')
     if ro is None:
         ro = get_ro('primary')
-    res = {}
+    res = {'residue': {}, 'position': {}}
     for stmt_type in get_all_descendants(Modification):
         stmt_name = stmt_type.__name__
         if stmt_name in ('Modification', 'AddModification',
@@ -152,10 +153,10 @@ def load_res_pos(ro=None):
                               ro.FastRawPaLink.type_num == type_num)
         for jsb, in query:
             js = json.loads(jsb)
-            if 'residue' in js or 'position' in js:
-                res[js['matches_hash']] = {'residue': js.get('residue'),
-                                           'position': js.get('position')}
-
+            if 'residue' in js:
+                res['residue'][js['matches_hash']] = js['residue']
+            if 'position' in js:
+                res['position'][js['matches_hash']] = js['position']
     return res
 
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -61,6 +61,35 @@ def load_pickle_from_s3(s3_path):
 
 
 def load_db_content(ns_list, pkl_filename=None, ro=None, reload=False):
+    """Get preassembled stmt metadata from the DB for export.
+
+    Queries the NameMeta, TextMeta, and OtherMeta tables as needed to get
+    agent/stmt metadata for agents from the given namespaces.
+
+    Parameters
+    ----------
+    ns_list : list of str
+        List of agent namespaces to include in the metadata query.
+    pkl_filename : str
+        Name of pickle file to save to (if reloading) or load from (if not
+        reloading). If an S3 path is given (i.e., pkl_filename starts with S3),
+        the file is loaded to/saved from S3. If not given, automatically
+        reloads the content (overriding reload).
+    ro : ReadonlyDatabaseManager
+        Readonly database to load the content from. If not given, calls
+        `get_ro('primary')` to get the primary readonly DB.
+    reload : bool
+        Whether to re-query the database for content or to load the content
+        from from `pkl_filename`. Note that even if `reload` is False,
+        if no `pkl_filename` is given, data will be reloaded anyway.
+
+    Returns
+    -------
+    set of tuples
+        Set of tuples containing statement information organized
+        by agent. Tuples contain (stmt_hash, agent_ns, agent_id, agent_num,
+        evidence_count, stmt_type).
+    """
     if isinstance(pkl_filename, str) and pkl_filename.startswith('s3:'):
         pkl_filename = S3Path.from_string(pkl_filename)
     # Get the raw data

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -1,5 +1,5 @@
 __all__ = ['load_db_content', 'make_dataframe', 'get_source_counts', 'NS_LIST',
-           'dump_sif']
+           'dump_sif', 'load_res_pos']
 
 import json
 import pickle

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -79,6 +79,7 @@ def load_db_content(ns_list, pkl_filename=None, ro=None, reload=False):
             else:
                 tbl = ro.OtherMeta
                 filters.append(tbl.db_name.like(ns))
+            filters.append(tbl.is_complex_dup == False)
             res = ro.select_all([tbl.mk_hash, tbl.db_id, tbl.ag_num,
                                  tbl.ev_count, tbl.type_num], *filters)
             results[ns] = res

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -182,7 +182,8 @@ def get_source_counts(pkl_filename=None, ro=None):
     return ev
 
 
-def make_dataframe(reconvert, db_content, pkl_filename=None):
+def make_dataframe(reconvert, db_content, res_pos_dict, src_count_dict,
+                   pkl_filename=None):
     """Make a pickled DataFrame of the db content, one row per stmt.
 
     Parameters
@@ -193,6 +194,8 @@ def make_dataframe(reconvert, db_content, pkl_filename=None):
         `pkl_filename` must be given.
     db_content : set of tuples
         Set of tuples of agent/stmt data as returned by `load_db_content`.
+    res_pos_dict : Dict[str, Dict[str, str]]
+    src_count_dict : Dict[str, Dict[str, int]]
     pkl_filename : str
         Name of pickle file to save to (if reconverting) or load from (if not
         reconverting). If an S3 path is given (i.e., pkl_filename starts with
@@ -293,15 +296,19 @@ def make_dataframe(reconvert, db_content, pkl_filename=None):
             # Add all the pairs, and count up total evidence.
             for pair in pairs:
                 row = OrderedDict([
-                        ('agA_ns', pair[0][0]),
-                        ('agA_id', pair[0][1]),
-                        ('agA_name', pair[0][2]),
-                        ('agB_ns', pair[1][0]),
-                        ('agB_id', pair[1][1]),
-                        ('agB_name', pair[1][2]),
-                        ('stmt_type', info_dict['type']),
-                        ('evidence_count', info_dict['ev_count']),
-                        ('stmt_hash', hash)])
+                    ('agA_ns', pair[0][0]),
+                    ('agA_id', pair[0][1]),
+                    ('agA_name', pair[0][2]),
+                    ('agB_ns', pair[1][0]),
+                    ('agB_id', pair[1][1]),
+                    ('agB_name', pair[1][2]),
+                    ('stmt_type', info_dict['type']),
+                    ('evidence_count', info_dict['ev_count']),
+                    ('stmt_hash', hash),
+                    ('residue', res_pos_dict['residue'].get(hash)),
+                    ('position', res_pos_dict['position'].get(hash)),
+                    ('source_count', src_count_dict.get(hash))
+                ])
                 rows.append(row)
         if nkey_errors:
             ef = 'key_errors.csv'

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -1,6 +1,7 @@
 __all__ = ['load_db_content', 'make_dataframe', 'get_source_counts', 'NS_LIST',
            'dump_sif']
 
+import json
 import pickle
 import logging
 import argparse
@@ -12,6 +13,7 @@ from tqdm import tqdm
 
 from indra.util.aws import get_s3_client
 from indra_db.schemas.readonly_schema import ro_type_map
+from indra.statements import get_all_descendants, Modification
 from indra.statements.agent import default_ns_order
 
 try:
@@ -132,6 +134,29 @@ def load_db_content(ns_list, pkl_filename=None, ro=None, reload=False):
                 results = pickle.load(f)
     logger.info("{len} stmts loaded".format(len=len(results)))
     return results
+
+
+def load_res_pos(ro=None):
+    """Return residue/position data keyed by hash"""
+    if ro is None:
+        ro = get_ro('primary')
+    res = {}
+    for stmt_type in get_all_descendants(Modification):
+        stmt_name = stmt_type.__name__
+        if stmt_name in ('Modification', 'AddModification',
+                         'RemoveModification'):
+            continue
+        logger.info(f'Getting statements for type {stmt_name}')
+        type_num = ro_type_map.get_int(stmt_name)
+        query = ro.select_all(ro.FastRawPaLink.pa_json,
+                              ro.FastRawPaLink.type_num == type_num)
+        for jsb, in query:
+            js = json.loads(jsb)
+            if 'residue' in js or 'position' in js:
+                res[js['matches_hash']] = {'residue': js.get('residue'),
+                                           'position': js.get('position')}
+
+    return res
 
 
 def get_source_counts(pkl_filename=None, ro=None):

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -168,9 +168,9 @@ def load_res_pos(ro=None):
         for jsb, in query:
             js = json.loads(jsb)
             if 'residue' in js:
-                res['residue'][js['matches_hash']] = js['residue']
+                res['residue'][int(js['matches_hash'])] = js['residue']
             if 'position' in js:
-                res['position'][js['matches_hash']] = js['position']
+                res['position'][int(js['matches_hash'])] = js['position']
     return res
 
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -52,9 +52,9 @@ def upload_pickle_to_s3(obj, s3_path):
 
 def load_pickle_from_s3(s3_path):
     logger.info('Loading pickle %s.' % s3_path)
-    s3 = get_s3_client(unsigned=False)
+    s3 = get_s3_client(False)
     try:
-        res = s3.get_object(**s3_path.kw())
+        res = s3_path.get(s3)
         obj = pickle.loads(res['Body'].read())
         logger.info('Finished loading %s.' % s3_path)
         return obj


### PR DESCRIPTION
This PR makes a couple of changes and additions:
- A bug where certain statements previously were inserted into the Sif dump with mismatching name-id has been fixed
- The `Sif` dump is now created with four additional columns: `residue`, `position` (both apply to `Modification` statements only), `source_count` and `belief`. `source_count` and `belief` previously had to be added as a separate post-processing step outside the scope of the dumping process and `residue` and `position` are completely new.
- A new dumper, `ResiduePosition`, is added to grab `residue` and `position` attributes from `Modification` statements.
- The source count dumping is now done as an independent dump step and not dumped as part of making the `Sif` dump.
- The `Sif` dump now works under the assumption that the dumps it is dependent on are dumped prior to it.
- The dump script has been re-ordered to reflect which dumps can be done independently and which ones depend on other dumps.
- The `FullPaJson` dump is now used instead of `FullPaStmts`, and its format has been changed to `jsonl` to accommodate processing it in chunks.
-  Various docstrings, comments and logger messages have been added/updated.