### PR TITLE
Fix column name in sif dump

### DIFF
--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -326,7 +326,7 @@ def make_dataframe(reconvert, db_content, res_pos_dict, src_count_dict,
                     ('stmt_hash', hash),
                     ('residue', res_pos_dict['residue'].get(hash)),
                     ('position', res_pos_dict['position'].get(hash)),
-                    ('source_count', src_count_dict.get(hash)),
+                    ('source_counts', src_count_dict.get(hash)),
                     ('belief', belief_dict.get(str(hash)))
                 ])
                 rows.append(row)


### PR DESCRIPTION
This PR fixes the column name in the sif dump for the source count dictionary.

The column name was previously `source_count`, but should be `source_counts` as that is what is expected in indra, see e.g. the [indranet assembler](https://github.com/sorgerlab/indra/blob/master/indra/assemblers/indranet/net.py#L117).