### PR TITLE
Refactor Content Updates

### DIFF
--- a/indra_db/cli/__init__.py
+++ b/indra_db/cli/__init__.py
@@ -101,7 +101,7 @@ def pipeline_stats(task):
 @click.argument("sources", nargs=-1,
                 type=click.Choice(["pubmed", "pmc_oa", "manuscripts"]),
                 required=False)
-@click.option("-n", "--num_procs", type=int, default=1,
+@click.option("-n", "--num_procs", type=int, default=None,
               help=('Select the number of processors to use during this '
                     'operation. Default is 1.'))
 @click.option('-c', '--continuing', is_flag=True,
@@ -142,12 +142,21 @@ def content_run(task, sources, num_procs, continuing, debug):
 
     # Perform the task.
     for ContentManager in selected_managers:
+        if ContentManager != Pubmed and num_procs is not None:
+            print("NOTE: Multiprocessing is only available in 'pubmed'.")
+
         if task == 'upload':
             print(f"Uploading {ContentManager.my_source}.")
-            ContentManager().populate(db, num_procs, continuing)
+            if ContentManager != Pubmed:
+                ContentManager().populate(db, continuing)
+            else:
+                ContentManager().populate(db, num_procs, continuing)
         elif task == 'update':
             print(f"Updating {ContentManager.my_source}")
-            ContentManager().update(db, num_procs)
+            if ContentManager != Pubmed:
+                ContentManager().update(db)
+            else:
+                ContentManager().update(db, num_procs)
 
 
 @main.command()

--- a/indra_db/cli/__init__.py
+++ b/indra_db/cli/__init__.py
@@ -101,15 +101,12 @@ def pipeline_stats(task):
 @click.argument("sources", nargs=-1,
                 type=click.Choice(["pubmed", "pmc_oa", "manuscripts"]),
                 required=False)
-@click.option("-n", "--num_procs", type=int, default=None,
-              help=('Select the number of processors to use during this '
-                    'operation. Default is 1.'))
 @click.option('-c', '--continuing', is_flag=True,
               help=('Continue uploading or updating, picking up where you left '
                     'off.'))
 @click.option('-d', '--debug', is_flag=True,
               help='Run with debugging level output.')
-def content_run(task, sources, num_procs, continuing, debug):
+def content_run(task, sources, continuing, debug):
     """Upload/update text refs and content on the database.
 
     \b
@@ -142,21 +139,12 @@ def content_run(task, sources, num_procs, continuing, debug):
 
     # Perform the task.
     for ContentManager in selected_managers:
-        if ContentManager != Pubmed and num_procs is not None:
-            print("NOTE: Multiprocessing is only available in 'pubmed'.")
-
         if task == 'upload':
             print(f"Uploading {ContentManager.my_source}.")
-            if ContentManager != Pubmed:
-                ContentManager().populate(db, continuing)
-            else:
-                ContentManager().populate(db, num_procs, continuing)
+            ContentManager().populate(db, continuing)
         elif task == 'update':
             print(f"Updating {ContentManager.my_source}")
-            if ContentManager != Pubmed:
-                ContentManager().update(db)
-            else:
-                ContentManager().update(db, num_procs)
+            ContentManager().update(db)
 
 
 @main.command()

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1481,6 +1481,8 @@ class Elsevier(ContentManager):
 
     def __select_elsevier_refs(self, tr_set, max_retries=2):
         """Try to check if this content is available on Elsevier."""
+        from indra.literature.pubmed_client import get_metadata_for_ids
+
         elsevier_tr_set = set()
         for tr in tr_set.copy():
             if tr.doi is not None:

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -668,8 +668,8 @@ class Pubmed(_NihManager):
             tr_records, flawed_refs, id_map = \
                 self.filter_text_refs(db, tr_records,
                                       primary_id_types=['pmid', 'pmcid'])
-            logger.info('%d new records to add to text_refs.'
-                        % len(tr_records))
+            logger.info(f"Found {len(tr_records)} refs to add, {len(id_map)} "
+                        f"refs updated.")
         else:
             id_map = {}
 

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -744,12 +744,14 @@ class Pubmed(_NihManager):
                     tr['annotations'] = data['mesh_annotations']
 
                 # Extract the content data
+                tc_list = []
                 for text_type in self.categories:
                     content = article_info[pmid].get(text_type)
                     if content and content.strip():
                         tc = {'pmid': pmid, 'text_type': text_type,
                               'content': zip_string(content)}
-                        yield (xml_file, idx, num_records), tr, tc
+                        tc_list.append(tc)
+                yield (xml_file, idx, num_records), tr, tc_list
 
     def load_files(self, db, files, continuing=False, carefully=False,
                    log_update=True):
@@ -795,7 +797,8 @@ class Pubmed(_NihManager):
             self.load_annotations(db, tr_batch)
             id_map = self.load_text_refs(db, tr_batch,
                                          update_existing=carefully)
-            self.load_text_content(db, tc_batch, id_map)
+            expanded_tcs = (tc for tc_list in tc_batch for tc in tc_list)
+            self.load_text_content(db, expanded_tcs, id_map)
 
             # Check if we finished an xml file.
             for file_name, info in archive_stats.items():

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -316,6 +316,7 @@ class ContentManager(object):
             match_id_types = primary_id_types
         else:
             match_id_types = self.tr_cols
+
         # Get IDs from the tr_data_set that have one or more of the listed
         # id types.
         for id_type in match_id_types:
@@ -509,14 +510,14 @@ class ContentManager(object):
     @classmethod
     def get_latest_update(cls, db):
         """Get the date of the latest update."""
-        update_list = db.select_all(db.Updates,
-                                    db.Updates.source == cls.my_source)
-        if not len(update_list):
+        last_dt, = (db.session.query(sql_exp.func.max(db.Updates.datetime))
+                    .filter(db.Updates.source == cls.my_source).one())
+        if not last_dt:
             logger.error("The database has not had an initial upload, or else "
                          "the updates table has not been populated.")
-            return False
+            return None
 
-        return max([u.datetime for u in update_list])
+        return last_dt
 
     def populate(self, db):
         "A stub for the method used to initially populate the database."

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -638,10 +638,10 @@ class Pubmed(_NihManager):
         logger.info("Fixing doubled doi: %s" % doi)
         return doi[:L//2]
 
-    def add_annotations(self, db, article_info):
+    def load_annotations(self, db, tr_data):
         """Load annotations into the database."""
-        for pmid, info_dict in article_info.items():
-            self.annotations[pmid] = info_dict['mesh_annotations']
+        for tr_dict in tr_data:
+            self.annotations[tr_dict['pmid']] = tr_dict['annotations']
 
         # Add mesh annotations to the db in batches.
         if len(self.annotations) > self.max_annotations:

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1114,7 +1114,8 @@ class PmcManager(_NihManager):
                 # Yield each XML file.
                 for n, xml_file in enumerate(xml_files):
                     # Skip the files we don't need.
-                    if pmcid_set is not None and xml_file not in desired_files:
+                    if pmcid_set is not None \
+                            and xml_file.name not in desired_files:
                         continue
                     xml_str = tar.extractfile(xml_file).read().decode('utf8')
                     yield (archive, n, len(xml_files)), xml_file.name, xml_str

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -538,7 +538,13 @@ class _NihManager(ContentManager):
 
 
 class Pubmed(_NihManager):
-    """Manager for the pubmed/medline content."""
+    """Manager for the pubmed/medline content.
+
+    For relevant updates from NCBI on the managemetn and upkeep of the PubMed
+    Abstract FTP server, see here:
+
+      https://www.nlm.nih.gov/databases/download/pubmed_medline.html
+    """
     my_path = 'pubmed'
     my_source = 'pubmed'
     tr_cols = ('pmid', 'pmcid', 'doi', 'pii', 'pub_year')
@@ -738,7 +744,7 @@ class Pubmed(_NihManager):
         return
 
     def upload_article(self, db, article_info, carefully=False):
-        "Process the content of an xml dataset and load into the database."
+        """Process the content of an xml dataset and load into the database."""
         logger.info("%d PMIDs in XML dataset" % len(article_info))
 
         self.add_annotations(db, article_info)
@@ -756,7 +762,7 @@ class Pubmed(_NihManager):
 
     def load_files(self, db, dirname, n_procs=1, continuing=False,
                    carefully=False, log_update=True):
-        """Load the files in subdirectory indicated by `dirname`."""
+        """Load the files in subdirectory indicated by ``dirname``."""
         if 'text_ref' not in self.tables:
             logger.info("Loading pmids from the database...")
             self.db_pmids = {pmid for pmid, in db.select_all(db.TextRef.pmid)}

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -573,6 +573,7 @@ class Pubmed(_NihManager):
     """
     my_path = 'pubmed'
     my_source = 'pubmed'
+    primary_col = 'pmid'
     tr_cols = ('pmid', 'pmcid', 'doi', 'pii', 'pub_year')
     tc_cols = ('text_ref_id', 'source', 'format', 'text_type', 'content',
                'license')
@@ -866,6 +867,7 @@ class Pubmed(_NihManager):
 class PmcManager(_NihManager):
     """Abstract class for uploaders of PMC content: PmcOA and Manuscripts."""
     my_source = NotImplemented
+    primary_col = 'pmcid'
     tr_cols = ('pmid', 'pmcid', 'doi', 'manuscript_id', 'pub_year',)
     tc_cols = ('text_ref_id', 'source', 'format', 'text_type',
                'content', 'license')

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -10,7 +10,6 @@ import xml.etree.ElementTree as ET
 from io import BytesIO
 from ftplib import FTP
 from functools import wraps
-from argparse import ArgumentParser
 from datetime import datetime, timedelta
 from os import path, remove, rename, listdir
 
@@ -23,7 +22,6 @@ from indra.literature import pubmed_client
 from indra.literature.pmc_client import id_lookup
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
-from indra_db.util import get_db
 from indra_db.databases import texttypes, formats
 from indra_db.databases import sql_expressions as sql_exp
 from indra_db.util.data_gatherer import DataGatherer, DGContext

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -603,7 +603,7 @@ class Pubmed(_NihManager):
         if doi is None:
             return
         L = len(doi)
-        if L % 2 is not 0:
+        if L % 2 != 0:
             return doi
         if doi[:L//2] != doi[L//2:]:
             return doi
@@ -818,7 +818,7 @@ class Pubmed(_NihManager):
                 upload_and_record_next(True)
                 n_tot -= 1
 
-            while n_tot is not 0:
+            while n_tot != 0:
                 upload_and_record_next(False)
                 n_tot -= 1
         else:
@@ -933,7 +933,7 @@ class PmcManager(_NihManager):
                 missing_pmid_entries.append(tr_entry)
 
         num_missing = len(missing_pmid_entries)
-        if num_missing is 0:
+        if num_missing == 0:
             logger.debug("No missing pmids.")
             return
 
@@ -1030,7 +1030,7 @@ class PmcManager(_NihManager):
                           for cause, rec in flawed_tr_records
                           if cause in ['pmcid', 'over_match_input',
                                        'over_match_db']}
-        if len(pmcids_to_skip) is not 0:
+        if len(pmcids_to_skip) != 0:
             mod_tc_data = [
                 tc for tc in tc_data if tc['pmcid'] not in pmcids_to_skip
                 ]
@@ -1208,7 +1208,7 @@ class PmcManager(_NihManager):
         active_list = []
 
         def start_next_proc():
-            if len(wait_list) is not 0:
+            if len(wait_list) != 0:
                 archive, proc = wait_list.pop(0)
                 proc.start()
                 active_list.append((archive, proc))
@@ -1221,13 +1221,13 @@ class PmcManager(_NihManager):
         batch_log = path.join(THIS_DIR, '%s_batch_log.tmp' % self.my_source)
         batch_entry_fmt = '%s %d\n'
         open(batch_log, 'a+').close()
-        while len(active_list) is not 0:
+        while len(active_list) != 0:
             # Check for processes that have been unpacking archives to
             # complete, and when they do, add them to the source_file table.
             # If there are any more archives waiting to be processed, start
             # the next one.
             for a, p in [(a, p) for a, p in active_list if not p.is_alive()]:
-                if p.exitcode is 0:
+                if p.exitcode == 0:
                     sf_list = db.select_all(
                         db.SourceFile,
                         db.SourceFile.source == self.my_source,
@@ -1386,7 +1386,7 @@ class Manuscripts(PmcManager):
         file_list = self.ftp.get_csv_as_dict('filelist.csv', header=0)
         pmcid_mid_dict = {entry['PMCID']: entry['MID'] for entry in file_list}
         pmid_mid_dict = {entry['PMID']: entry['MID'] for entry in file_list
-                         if entry['PMID'] is not '0'}
+                         if entry['PMID'] != '0'}
         for tr in tr_list:
             if tr.pmcid is not None:
                 tr.manuscript_id = pmcid_mid_dict[tr.pmcid]
@@ -1543,7 +1543,7 @@ class Elsevier(ContentManager):
                     continue
 
                 tr_batch.add(tr)
-                if len(tr_batch) % 200 is 0:
+                if len(tr_batch) % 200 == 0:
                     batch_num += 1
                     logger.info('Beginning batch %d.' % batch_num)
                     self.__process_batch(db, tr_batch)

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -735,7 +735,8 @@ class Pubmed(_NihManager):
             valid_article_pmids = set(article_info.keys()) - invalid_pmids
 
             # Yield results for each PMID.
-            for pmid in valid_article_pmids:
+            num_records = len(valid_article_pmids)
+            for idx, pmid in enumerate(valid_article_pmids):
                 data = article_info[pmid]
 
                 # Extract the ref data.
@@ -761,7 +762,7 @@ class Pubmed(_NihManager):
                     if content and content.strip():
                         tc = {'pmid': pmid, 'text_type': text_type,
                               'content': zip_string(content)}
-                        yield (xml_file, pmid, text_type), tr, tc
+                        yield (xml_file, idx, num_records), tr, tc
 
     def load_files(self, db, files, n_procs=1, continuing=False,
                    carefully=False, log_update=True):

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -704,7 +704,24 @@ class Pubmed(_NihManager):
         return
 
     def iter_contents(self, archives=None):
-        """Iterate over the contents."""
+        """Iterate over the files in the archive, yielding ref and content data.
+
+        Parameters
+        ----------
+        archives : Optional[Iterable[str]]
+            The names of the archive files from the FTP server to processes. If
+            None, all available archives will be iterated over.
+
+        Yields
+        ------
+        label : tuple
+            A key representing the particular XML: (XML File Name, Entry Number,
+            Total Entries)
+        text_ref_dict : dict
+            A dictionary containing the text ref information.
+        text_content_dict : dict
+            A dictionary containing the text content information.
+        """
         from indra.literature.pubmed_client import get_metadata_from_xml_tree
 
         if archives is None:
@@ -1084,7 +1101,33 @@ class PmcManager(_NihManager):
         return archive_local_path
 
     def iter_xmls(self, archives=None, continuing=False, pmcid_set=None):
-        """Iterate over the xmls in the given archives."""
+        """Iterate over the xmls in the given archives.
+
+        Parameters
+        ----------
+        archives : Optional[Iterable[str]]
+            The names of the archive files from the FTP server to processes. If
+            None, all available archives will be iterated over.
+        continuing : Optional[Bool]
+            If True, look for locally saved archives to parse, saving the time
+            of downloading.
+        pmcid_set : Optional[set[str]]
+            A set of PMCIDs whose content you want returned from each archive.
+            Many archives are massive repositories with 10s of thousands of
+            papers in each, and only a fraction may need to be returned.
+            Extracting and processing XMLs can be time consuming, so skipping
+            those you don't need can really pay off!
+
+        Yields
+        ------
+        label : Tuple
+            A key representing the particular XML: (Archive Name, Entry Number,
+            Total Entries)
+        xml_name : str
+            The name of the XML file.
+        xml_str : str
+            The extracted XML string.
+        """
         # By default, iterate through all the archives.
         if archives is None:
             archives = set(self.get_all_archives())
@@ -1140,6 +1183,31 @@ class PmcManager(_NihManager):
 
     def iter_contents(self, archives=None, continuing=False, pmcid_set=None):
         """Iterate over the files in the archive, yielding ref and content data.
+
+        Parameters
+        ----------
+        archives : Optional[Iterable[str]]
+            The names of the archive files from the FTP server to processes. If
+            None, all available archives will be iterated over.
+        continuing : Optional[Bool]
+            If True, look for locally saved archives to parse, saving the time
+            of downloading.
+        pmcid_set : Optional[set[str]]
+            A set of PMCIDs whose content you want returned from each archive.
+            Many archives are massive repositories with 10s of thousands of
+            papers in each, and only a fraction may need to be returned.
+            Extracting and processing XMLs can be time consuming, so skipping
+            those you don't need can really pay off!
+
+        Yields
+        ------
+        label : tuple
+            A key representing the particular XML: (Archive Name, Entry Number,
+            Total Entries)
+        text_ref_dict : dict
+            A dictionary containing the text ref information.
+        text_content_dict : dict
+            A dictionary containing the text content information.
         """
         xml_iter = self.iter_xmls(archives, continuing, pmcid_set)
         for label, file_name, xml_str in xml_iter:

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -867,11 +867,11 @@ class PmcManager(_NihManager):
     """Abstract class for uploaders of PMC content: PmcOA and Manuscripts."""
     my_source = NotImplemented
     tr_cols = ('pmid', 'pmcid', 'doi', 'manuscript_id', 'pub_year',)
+    tc_cols = ('text_ref_id', 'source', 'format', 'text_type',
+               'content', 'license')
 
     def __init__(self, *args, **kwargs):
         super(PmcManager, self).__init__(*args, **kwargs)
-        self.tc_cols = ('text_ref_id', 'source', 'format', 'text_type',
-                        'content',)
 
     def update(self, db):
         raise NotImplementedError

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -525,6 +525,12 @@ class _NihManager(ContentManager):
     """
     my_path = NotImplemented
 
+    def update(self, db):
+        raise NotImplementedError
+
+    def populate(self, db):
+        raise NotImplementedError
+
     def __init__(self, *args, **kwargs):
         self.ftp = _NihFtpClient(self.my_path, *args, **kwargs)
         super(_NihManager, self).__init__()
@@ -532,7 +538,7 @@ class _NihManager(ContentManager):
 
 
 class Pubmed(_NihManager):
-    "Manager for the pubmed/medline content."
+    """Manager for the pubmed/medline content."""
     my_path = 'pubmed'
     my_source = 'pubmed'
     tr_cols = ('pmid', 'pmcid', 'doi', 'pii',)
@@ -585,8 +591,9 @@ class Pubmed(_NihManager):
         else:
             return article_info
 
-    def fix_doi(self, doi):
-        "Sometimes the doi is doubled (no idea why). Fix it."
+    @staticmethod
+    def fix_doi(doi):
+        """Sometimes the doi is doubled (no idea why). Fix it."""
         if doi is None:
             return
         L = len(doi)
@@ -598,7 +605,7 @@ class Pubmed(_NihManager):
         return doi[:L//2]
 
     def add_annotations(self, db, article_info):
-        "Load annotations into the database."
+        """Load annotations into the database."""
         for pmid, info_dict in article_info.items():
             self.annotations[pmid] = info_dict['mesh_annotations']
 
@@ -897,8 +904,12 @@ class PmcManager(_NihManager):
         self.tc_cols = ('text_ref_id', 'source', 'format', 'text_type',
                         'content',)
 
-    def get_missing_pmids(self, db, tr_data):
-        "Try to get missing pmids using the pmc client."
+    def update(self, db):
+        raise NotImplementedError
+
+    @staticmethod
+    def get_missing_pmids(db, tr_data):
+        """Try to get missing pmids using the pmc client."""
 
         logger.info("Getting missing pmids.")
 
@@ -939,7 +950,7 @@ class PmcManager(_NihManager):
         return
 
     def filter_text_content(self, db, tc_data):
-        'Filter the text content to identify pre-existing records.'
+        """Filter the text content to identify pre-existing records."""
         logger.info("Beginning to filter text content...")
         arc_pmcid_list = [tc['pmcid'] for tc in tc_data]
         if not len(tc_data):
@@ -988,7 +999,7 @@ class PmcManager(_NihManager):
         return list(set(filtered_tc_records))
 
     def upload_batch(self, db, tr_data, tc_data):
-        "Add a batch of text refs and text content to the database."
+        """Add a batch of text refs and text content to the database."""
 
         # Check for any pmids we can get from the pmc client (this is slow!)
         self.get_missing_pmids(db, tr_data)

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1047,9 +1047,14 @@ class PmcManager(_NihManager):
         tc_datum = {
             'pmcid': id_data['pmcid'],
             'text_type': texttypes.FULLTEXT,
+            'license': self.get_license(id_data['pmcid']),
             'content': zip_string(xml_str)
             }
         return tr_datum, tc_datum
+
+    def get_license(self, pmcid):
+        """Get the license for this pmcid."""
+        raise NotImplementedError()
 
     def download_archive(self, archive, continuing=False):
         """Download the archive."""
@@ -1238,6 +1243,14 @@ class PmcOA(PmcManager):
     my_path = 'pub/pmc'
     my_source = 'pmc_oa'
 
+    def __init__(self, *args, **kwargs):
+        super(PmcOA, self).__init__(*args, **kwargs)
+        self.licenses = {d['Accession ID']: d['License']
+                         for d in self.get_file_data()}
+
+    def get_license(self, pmcid):
+        return self.licenses[pmcid]
+
     def is_archive(self, k):
         return k.endswith('.xml.tar.gz')
 
@@ -1292,6 +1305,9 @@ class Manuscripts(PmcManager):
     """
     my_path = 'pub/pmc/manuscript'
     my_source = 'manuscripts'
+
+    def get_license(self, pmcid):
+        return 'manuscripts'
 
     def get_file_data(self):
         return self.ftp.get_csv_as_dict("filelist.csv")

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -838,8 +838,8 @@ class Pubmed(_NihManager):
                 copy_rows.append(copy_row)
 
         # Copy the results into the database
-        db.copy_lazy(db, 'mesh_ref_annotations', copy_rows,
-                     ('pmid_num', 'mesh_num', 'major_topic','is_concept',
+        db.copy_lazy('mesh_ref_annotations', copy_rows,
+                     ('pmid_num', 'mesh_num', 'major_topic', 'is_concept',
                       'qual_num'))
         return True
 

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -952,20 +952,13 @@ class PmcManager(_NihManager):
                 logger.warning("Found pmcid (%s) among text content data, but "
                                "not in the database. Skipping." % tc['pmcid'])
                 continue
-            tc_records.append(
-                (
-                    pmcid_trid_dict[tc['pmcid']],
-                    self.my_source,
-                    formats.XML,
-                    tc['text_type'],
-                    tc['user_input']
-                    )
-                )
-        filtered_tc_records = [
-            rec for rec in tc_records if rec[:-1] not in existing_tc_records
-            ]
+            tc_records.append((pmcid_trid_dict[tc['pmcid']], self.my_source,
+                               formats.XML, tc['text_type'], tc['content'],
+                               tc['license']))
+        filtered_tc_records = {rec for rec in tc_records
+                               if rec[:-2] not in existing_tc_records}
         logger.info("Finished filtering the text content.")
-        return list(set(filtered_tc_records))
+        return filtered_tc_records
 
     def upload_batch(self, db, tr_data, tc_data):
         """Add a batch of text refs and text content to the database."""

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -260,10 +260,10 @@ class ContentManager(object):
         ref_data = new_data
 
         ret_cols = (self.primary_col, 'id')
-        id_tuples, skipped = \
-            db.copy_report_and_return_lazy('text_ref', ref_data, cols, ret_cols)
-        id_dict = dict(id_tuples)
-        return id_dict, skipped
+        existing_tuples, new_tuples, skipped_rows = \
+            db.copy_detailed_report_lazy('text_ref', ref_data, cols, ret_cols)
+        id_dict = dict(new_tuples + existing_tuples)
+        return id_dict, skipped_rows
 
     def upload_text_content(self, db, data):
         """Insert text content into the database using COPY."""

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -898,9 +898,9 @@ class Pubmed(_NihManager):
                 copy_rows.append(copy_row)
 
         # Copy the results into the database
-        self.copy_into_db(db, 'mesh_ref_annotations', copy_rows,
-                          ('pmid_num', 'mesh_num', 'major_topic','is_concept',
-                           'qual_num'))
+        db.copy_lazy(db, 'mesh_ref_annotations', copy_rows,
+                     ('pmid_num', 'mesh_num', 'major_topic','is_concept',
+                      'qual_num'))
         return True
 
     def load_files_and_annotations(self, db, *args, **kwargs):

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1393,7 +1393,9 @@ class Manuscripts(PmcManager):
                            for pmcid in load_pmcid_set}
 
         logger.info("Beginning to upload archives.")
-        self.upload_archives(db, update_archives, pmcid_set=load_pmcid_set)
+        for archive in update_archives:
+            self.upload_archives(db, [archive],
+                                 pmcid_set=load_pmcid_set)
         return True
 
 

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -100,17 +100,31 @@ class _NihFtpClient(object):
         logger.info("Parsing XML metadata")
         return ET.XML(xml_bytes, parser=UTB())
 
-    def get_csv_as_dict(self, csv_file, cols=None, header=None):
-        "Get the content from a csv file as a list of dicts."
+    def get_csv_as_dict(self, csv_file, cols=None, infer_header=True):
+        """Get the content from a csv file as a list of dicts.
+
+        Parameters
+        ----------
+        csv_file : str
+            The name of the csv file within the target FTP directory.
+        cols : Iterable[str]
+            Pass in labels for the columns of the CSV.
+        infer_header : bool
+            If True, infer the cols from the first line. If False, the cols
+            will simply be indexed by integers.
+        """
         csv_str = self.get_file(csv_file)
-        lst = [row for row in csv.reader(csv_str.splitlines())]
-        if cols is None:
-            if header is not None:
-                cols = lst[header]
-                lst = lst[header+1:]
-            else:
-                cols = list(range(len(lst[0])))
-        return [dict(zip(cols, row)) for row in lst]
+        csv_lines = csv_str.splitlines()
+        result = []
+        for row in csv.reader(csv_lines):
+            if not cols:
+                if infer_header:
+                    cols = row[:]
+                    continue
+                else:
+                    cols = list(range(len(row)))
+            result.append(dict(zip(cols, row)))
+        return result
 
     def ret_file(self, f_path, buf):
         "Load the content of a file into the given buffer."

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -595,6 +595,7 @@ class Pubmed(_NihManager):
 
         self.db_pmids = None
         self.max_annotations = max_annotations
+        self.num_annotations = 0
         self.annotations = {}
         return
 
@@ -643,11 +644,13 @@ class Pubmed(_NihManager):
         """Load annotations into the database."""
         for tr_dict in tr_data:
             self.annotations[tr_dict['pmid']] = tr_dict['annotations']
+            self.num_annotations += len(tr_dict['annotations'])
 
         # Add mesh annotations to the db in batches.
-        if len(self.annotations) > self.max_annotations:
+        if self.num_annotations > self.max_annotations:
             self.dump_annotations(db)
             self.annotations = {}
+            self.num_annotations = 0
 
         return
 

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -550,6 +550,19 @@ class _NihManager(ContentManager):
         return
 
 
+def summarize_content_labels(label_list):
+    archive_stats = {}
+    for archive_name, file_num, num_files in label_list:
+        if archive_name not in archive_stats:
+            archive_stats[archive_name] = {'min': num_files, 'max': 0,
+                                           'tot': num_files}
+        if file_num < archive_stats[archive_name]['min']:
+            archive_stats[archive_name]['min'] = file_num
+        elif file_num > archive_stats[archive_name]['max']:
+            archive_stats[archive_name]['max'] = file_num
+    return archive_stats
+
+
 class Pubmed(_NihManager):
     """Manager for the pubmed/medline content.
 
@@ -1241,15 +1254,7 @@ class PmcManager(_NihManager):
         for i, (lbls, trs, tcs) in enumerate(batched_contents):
 
             # Figure out where we are in the list of archives.
-            archive_stats = {}
-            for archive_name, file_num, num_files in lbls:
-                if archive_name not in archive_stats:
-                    archive_stats[archive_name] = {'min': num_files, 'max': 0,
-                                                   'tot': num_files}
-                if file_num < archive_stats[archive_name]['min']:
-                    archive_stats[archive_name]['min'] = file_num
-                elif file_num > archive_stats[archive_name]['max']:
-                    archive_stats[archive_name]['max'] = file_num
+            archive_stats = summarize_content_labels(lbls)
 
             # Log where we are.
             logger.info(f"Beginning batch {i}...")

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -652,22 +652,10 @@ class Pubmed(_NihManager):
 
     def load_text_refs(self, db, tr_data, update_existing=False):
         """Sanitize, update old, and upload new text refs."""
-
-        # Remove existing pmids if we're not being careful (this suffices for
-        # filtering in the initial upload).
-        if not update_existing:
-            existing_pmids = {pmid for pmid, in db.select_all(db.TextRef.pmid)}
-        else:
-            existing_pmids = set()
-
         # Convert the article_info into a list of tuples for insertion into
         # the text_ref table
         tr_records = set()
-        pmids = set()
         for tr in tr_data:
-            if tr['pmid'] in existing_pmids:
-                continue
-            pmids.add(tr['pmid'])
             row = tuple(tr.get(col) for col in self.tr_cols)
             tr_records.add(row)
 

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1274,7 +1274,11 @@ class PmcOA(PmcManager):
     my_source = 'pmc_oa'
 
     def is_archive(self, k):
-        return k.startswith('articles') and k.endswith('.xml.tar.gz')
+        return k.endswith('.xml.tar.gz')
+
+    def get_all_archives(self):
+        return [path.join('oa_bulk', k) for k in self.ftp.ftp_ls('oa_bulk')
+                if self.is_archive(k)]
 
     def get_file_data(self):
         """Retrieve the metdata provided by the FTP server for files."""

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1073,14 +1073,9 @@ class PmcManager(_NihManager):
         else:
             mod_tc_data = tc_data
 
-        # Upload the text content data.
+        # Upload the text ref data.
         logger.info('Adding %d new text refs...' % len(filtered_tr_records))
-        self.copy_into_db(
-            db,
-            'text_ref',
-            filtered_tr_records,
-            self.tr_cols
-            )
+        self.upload_text_refs(db, filtered_tr_records)
         gatherer.add('refs', len(filtered_tr_records))
 
         # Process the text content data
@@ -1089,12 +1084,7 @@ class PmcManager(_NihManager):
         # Upload the text content data.
         logger.info('Adding %d more text content entries...' %
                     len(filtered_tc_records))
-        self.copy_into_db(
-            db,
-            'text_content',
-            filtered_tc_records,
-            self.tc_cols
-            )
+        self.upload_text_content(db, filtered_tc_records)
         gatherer.add('content', len(filtered_tc_records))
         return
 

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -923,7 +923,7 @@ class Pubmed(_NihManager):
 class PmcManager(_NihManager):
     """Abstract class for uploaders of PMC content: PmcOA and Manuscripts."""
     my_source = NotImplemented
-    tr_cols = ('pmid', 'pmcid', 'doi', 'manuscript_id', 'year',)
+    tr_cols = ('pmid', 'pmcid', 'doi', 'manuscript_id', 'pub_year',)
 
     def __init__(self, *args, **kwargs):
         super(PmcManager, self).__init__(*args, **kwargs)
@@ -1108,7 +1108,7 @@ class PmcManager(_NihManager):
         tr_datum_raw = {k: id_data.get(k) for k in self.tr_cols}
         tr_datum = {k: val.strip().upper() if val is not None else None
                     for k, val in tr_datum_raw.items()}
-        tr_datum['year'] = year
+        tr_datum['pub_year'] = year
 
         # Format the text content datum.
         tc_datum = {

--- a/indra_db/copy.py
+++ b/indra_db/copy.py
@@ -1,4 +1,5 @@
-__all__ = ['CopyManager', 'LazyCopyManager', 'PushCopyManager']
+__all__ = ['CopyManager', 'LazyCopyManager', 'PushCopyManager',
+           'ReturningCopyManager']
 
 import logging
 import tempfile

--- a/indra_db/copy.py
+++ b/indra_db/copy.py
@@ -103,12 +103,13 @@ class ReturningCopyManager(LazyCopyManager):
         self.return_cols = return_cols
         return
 
-    def report_copy(self, data, order_by=None, return_cols=None,
-                    fobject_factory=tempfile.TemporaryFile):
+    def detailed_report_copy(self, data, compare_cols, return_cols, order_by,
+                             fobject_factory=tempfile.TemporaryFile):
         self.copy(data, fobject_factory)
+        ex_cols = self._get_existing(compare_cols)
         ret_cols = self._insert_with_return()
         skipped_rows = self._get_skipped(len(data), order_by, return_cols)
-        return ret_cols, skipped_rows
+        return ex_cols, ret_cols, skipped_rows
 
     def _get_sql(self):
         return self._get_copy_sql()

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -807,7 +807,7 @@ class DatabaseManager(object):
         # General overhead.
         if not self._precheck_copy(tbl_name, data,
                                    'copy_report_and_return_lazy'):
-            return [], []
+            return [], [], []
         inp_cols, data_bts = self._prep_copy(tbl_name, data, inp_cols)
 
         # Handle guessed-parameters

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -637,7 +637,7 @@ class DatabaseManager(object):
         """
         return random.randint(-2**30, 2**30)
 
-    def _precheck_copy(self, data, tbl_name, meth_name):
+    def _precheck_copy(self, tbl_name, data, meth_name):
         logger.info(f"Received request to '{meth_name}' {len(data)} entries "
                     f"into table '{tbl_name}'.")
         if not CAN_COPY:

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -736,9 +736,7 @@ class DatabaseManager(object):
 
         tbl = self.tables[tbl_name]
 
-        constraints = [c.name for c in tbl.__table_args__
-                       if isinstance(c, UniqueConstraint)
-                       and set(c.columns.keys()) < set(cols)]
+        constraints = [c.name for c in tbl.iter_constraints(cols)]
 
         # Include the primary key in the list, if applicable.
         if inspect(tbl).primary_key[0].name in cols:
@@ -761,6 +759,16 @@ class DatabaseManager(object):
                              "cannot guess a foreign key "
                              "constraint.")
         return constraint
+
+    def _get_constraint_cols(self, constraint, tbl_name, cols):
+        """Get the column pairs in cols involved in unique constraints."""
+        tbl = self.tables[tbl_name]
+        if constraint is None:
+            constraint_cols = [tuple(c.columns.keys())
+                               for c in tbl.iter_constraints(cols)]
+        else:
+            constraint_cols = [constraint.columns.keys()]
+        return constraint_cols
 
     def copy_report_lazy(self, tbl_name, data, cols=None, commit=True,
                          constraint=None, return_cols=None, order_by=None):

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -9,7 +9,6 @@ import logging
 import string
 from io import BytesIO
 from numbers import Number
-from functools import wraps
 from datetime import datetime
 from time import sleep
 
@@ -77,30 +76,6 @@ try:
 except ImportError as e:
     logger.warning("Copy utilities unavailable: %s" % str(e))
     CAN_COPY = False
-
-
-def _copy_method(get_null_return=lambda: None):
-    def super_wrapper(meth):
-        @wraps(meth)
-        def wrapper(obj, tbl_name, data, cols=None, commit=True, *args, **kwargs):
-            logger.info("Received request to %s %d entries into %s."
-                        % (meth.__name__, len(data), tbl_name))
-            if not CAN_COPY:
-                raise RuntimeError("Cannot use copy methods. `pg_copy` is not "
-                                   "available.")
-            if obj.is_protected():
-                raise RuntimeError("Attempt to copy while in protected mode!")
-            if len(data) == 0:
-                return get_null_return()  # Nothing to do....
-
-            res = meth(obj, tbl_name, data, cols, commit, *args, **kwargs)
-
-            if commit:
-                obj.commit_copy('Failed to commit %s.' % meth.__name__)
-
-            return res
-        return wrapper
-    return super_wrapper
 
 
 def _isiterable(obj):
@@ -662,10 +637,21 @@ class DatabaseManager(object):
         """
         return random.randint(-2**30, 2**30)
 
+    def _precheck_copy(self, data, tbl_name, meth_name):
+        logger.info(f"Received request to '{meth_name}' {len(data)} entries "
+                    f"into table '{tbl_name}'.")
+        if not CAN_COPY:
+            raise RuntimeError("Cannot use copy methods. `pg_copy` is not "
+                               "available.")
+        if self.is_protected():
+            raise RuntimeError("Attempt to copy while in protected mode!")
+        if len(data) == 0:
+            return False
+        return True
+
     def _prep_copy(self, tbl_name, data, cols):
-        if self.__protected:
-            logger.error("Manager is in protected mode, no writes allowed!")
-            return
+        assert not self.__protected,\
+            "This should not be called if db in protected mode."
 
         # If cols is not specified, use all the cols in the table, else check
         # to make sure the names are valid.
@@ -726,35 +712,16 @@ class DatabaseManager(object):
 
         return cols, data_bts
 
-    @_copy_method(list)
-    def copy_report_lazy(self, tbl_name, data, cols=None, commit=True,
-                         constraint=None, return_cols=None, order_by=None):
-        """Copy lazily, and report what rows were skipped."""
-        cols, data_bts = self._prep_copy(tbl_name, data, cols)
-
+    def _infer_copy_order_by(self, order_by, tbl_name):
         if not order_by:
             order_by = getattr(self.tables[tbl_name],
                                '_default_insert_order_by')
             if not order_by:
                 raise ValueError("%s does not have an `order_by` attribute, "
                                  "and no `order_by` was specified." % tbl_name)
+        return order_by
 
-        mngr = LazyCopyManager(self._conn, tbl_name, cols,
-                               constraint=constraint)
-        return mngr.report_copy(data_bts, order_by, return_cols, BytesIO)
-
-    @_copy_method()
-    def copy_lazy(self, tbl_name, data, cols=None, commit=True,
-                  constraint=None):
-        "Copy lazily, skip any rows that violate constraints."
-        cols, data_bts = self._prep_copy(tbl_name, data, cols)
-
-        mngr = LazyCopyManager(self._conn, tbl_name, cols,
-                               constraint=constraint)
-        mngr.copy(data_bts, BytesIO)
-        return
-
-    def _infer_constraint(self, tbl_name, cols):
+    def _infer_copy_constraint(self, constraint, tbl_name, cols):
         """Try to infer a single constrain for a given table and columns.
 
         Look for table arguments that are constraints, and moreover that
@@ -764,6 +731,9 @@ class DatabaseManager(object):
         process will not catch foreign key constraints, which may not even
         apply.
         """
+        if constraint:
+            return constraint
+
         tbl = self.tables[tbl_name]
 
         constraints = [c.name for c in tbl.__table_args__
@@ -792,46 +762,129 @@ class DatabaseManager(object):
                              "constraint.")
         return constraint
 
-    @_copy_method()
-    def copy_push(self, tbl_name, data, cols=None, commit=True,
-                  constraint=None):
-        "Copy, pushing any changes to constraint violating rows."
+    def copy_report_lazy(self, tbl_name, data, cols=None, commit=True,
+                         constraint=None, return_cols=None, order_by=None):
+        """Copy lazily, and report what rows were skipped."""
+        # General overhead.
+        if not self._precheck_copy(tbl_name, data, 'copy_report_lazy'):
+            return []
         cols, data_bts = self._prep_copy(tbl_name, data, cols)
 
-        if constraint is None:
-            constraint = self._infer_constraint(tbl_name, cols)
+        # Guess parameters.
+        constraint = self._infer_copy_constraint(constraint, tbl_name, cols)
+        order_by = self._infer_copy_order_by(order_by, tbl_name)
 
+        # Do the copy.
+        mngr = LazyCopyManager(self._conn, tbl_name, cols,
+                               constraint=constraint)
+        ret = mngr.report_copy(data_bts, order_by, return_cols, BytesIO)
+
+        # Commit the copy.
+        if commit:
+            self.commit_copy(f'Failed to commit copy_report_lazy to '
+                             f'{tbl_name}.')
+
+        return ret
+
+    def copy_report_and_return_lazy(self, tbl_name, data, inp_cols=None,
+                                    ret_cols=None, commit=True, constraint=None,
+                                    skipped_cols=None, order_by=None):
+        """Copy lazily, returning data from some of the columns such as IDs."""
+        # General overhead.
+        if not self._precheck_copy(tbl_name, data,
+                                   'copy_report_and_return_lazy'):
+            return [], []
+        inp_cols, data_bts = self._prep_copy(tbl_name, data, inp_cols)
+
+        # Handle guessed-parameters
+        constraint = self._infer_copy_constraint(constraint, tbl_name, inp_cols)
+        order_by = self._infer_copy_order_by(order_by, tbl_name)
+        if ret_cols is None:
+            ret_cols = (self.get_primary_key(tbl_name).name,)
+
+        # Do the copy.
+        mngr = ReturningCopyManager(self._conn, tbl_name, inp_cols, ret_cols,
+                                    constraint=constraint)
+        ret = mngr.report_copy(data_bts, order_by, skipped_cols)
+
+        # Commit
+        if commit:
+            self.commit_copy(f'Failed to commit copy_report_and_return_lazy to '
+                             f'{tbl_name}.')
+
+        return ret
+
+    def copy_lazy(self, tbl_name, data, cols=None, commit=True,
+                  constraint=None):
+        """Copy lazily, skip any rows that violate constraints."""
+        # General overhead.
+        if not self._precheck_copy(tbl_name, data, 'copy_lazy'):
+            return
+        cols, data_bts = self._prep_copy(tbl_name, data, cols)
+
+        # Handle guessed-parameters
+        constraint = self._infer_copy_constraint(constraint, tbl_name, cols)
+
+        # Do the copy.
+        mngr = LazyCopyManager(self._conn, tbl_name, cols,
+                               constraint=constraint)
+        mngr.copy(data_bts, BytesIO)
+
+        # Commit
+        if commit:
+            self.commit_copy(f'Failed to commit copy_lazy to {tbl_name}.')
+
+        return
+
+    def copy_push(self, tbl_name, data, cols=None, commit=True,
+                  constraint=None):
+        """Copy, pushing any changes to constraint violating rows."""
+        # General overhead.
+        if not self._precheck_copy(tbl_name, data, 'copy_push'):
+            return
+        cols, data_bts = self._prep_copy(tbl_name, data, cols)
+
+        # Handle guessed-parameters
+        constraint = self._infer_copy_constraint(constraint, tbl_name, cols)
+
+        # Do the copy.
         mngr = PushCopyManager(self._conn, tbl_name, cols,
                                constraint=constraint)
         mngr.copy(data_bts, BytesIO)
+
+        # Commit
+        if commit:
+            self.commit_copy(f'Failed to commit copy_push to {tbl_name}.')
         return
 
-    @_copy_method(list)
     def copy_report_push(self, tbl_name, data, cols=None, commit=True,
                          constraint=None, return_cols=None, order_by=None):
         """Report on the rows skipped when pushing and copying."""
+        if not self._precheck_copy(tbl_name, data, 'copy_report_push'):
+            return
         cols, data_bts = self._prep_copy(tbl_name, data, cols)
 
-        if constraint is None:
-            constraint = self._infer_constraint(tbl_name, cols)
-
-        if not order_by:
-            order_by = self.tables[tbl_name]._default_insert_order_by
-            if not order_by:
-                raise ValueError("Table %s have no `_default_insert_order_by` "
-                                 "attribute, and no `order_by` was specified."
-                                 % tbl_name)
+        constraint = self._infer_copy_constraint(constraint, tbl_name, cols)
+        order_by = self._infer_copy_order_by(order_by, tbl_name)
 
         mngr = PushCopyManager(self._conn, tbl_name, cols,
                                constraint=constraint)
-        return mngr.report_copy(data_bts, order_by, return_cols, BytesIO)
+        ret = mngr.report_copy(data_bts, order_by, return_cols, BytesIO)
 
-    @_copy_method()
+        if commit:
+            self.commit_copy(f'Failed to commit copy_report_push to '
+                             f'{tbl_name}.')
+        return ret
+
     def copy(self, tbl_name, data, cols=None, commit=True):
-        "Use pg_copy to copy over a large amount of data."
+        """Use pg_copy to copy over a large amount of data."""
+        if not self._precheck_copy(tbl_name, data, 'copy'):
+            return
         cols, data_bts = self._prep_copy(tbl_name, data, cols)
         mngr = CopyManager(self._conn, tbl_name, cols)
         mngr.copy(data_bts, BytesIO)
+        if commit:
+            self.commit_copy(f'Failed to commit copy to {tbl_name}.')
         return
 
     def filter_query(self, tbls, *args):
@@ -877,6 +930,8 @@ class DatabaseManager(object):
 
     def get_primary_key(self, tbl):
         """Get an instance for the primary key column of a given table."""
+        if isinstance(tbl, str):
+            tbl = self.tables[tbl]
         return inspect(tbl).primary_key[0]
 
     def select_one(self, tbls, *args):

--- a/indra_db/schemas/mixins.py
+++ b/indra_db/schemas/mixins.py
@@ -1,7 +1,8 @@
 import logging
 from termcolor import colored
 from psycopg2.errors import DuplicateTable
-from sqlalchemy import inspect, Column, BigInteger, tuple_, and_
+from sqlalchemy import inspect, Column, BigInteger, tuple_, and_, \
+    UniqueConstraint
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 
@@ -41,6 +42,13 @@ class IndraDBTable(metaclass=IndraDBTableMetaClass):
     _skip_disp = []
     _always_disp = ['id']
     _default_insert_order_by = 'id'
+
+    @classmethod
+    def iter_constraints(cls, cols=None):
+        for tbl_arg in cls.__table_args__:
+            if isinstance(tbl_arg, UniqueConstraint):
+                if cols is None or set(tbl_arg.columns.keys()) < set(cols):
+                    yield tbl_arg
 
     @classmethod
     def create_index(cls, db, index, commit=True):

--- a/indra_db/schemas/mixins.py
+++ b/indra_db/schemas/mixins.py
@@ -51,6 +51,13 @@ class IndraDBTable(metaclass=IndraDBTableMetaClass):
                     yield tbl_arg
 
     @classmethod
+    def get_constraint(cls, name):
+        for constraint in cls.iter_constraints():
+            if constraint.name == name:
+                return constraint
+        return None
+
+    @classmethod
     def create_index(cls, db, index, commit=True):
         full_name = cls.full_name(force_schema=True)
         sql = (f"CREATE INDEX {index.name} ON {full_name} "

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -395,6 +395,8 @@ class PrincipalSchema(Schema):
           "abstract" of "fulltext".
         - **preprint** ``boolean``: Indicate whether the content is from
           a preprint.
+        - **license** [``varchar``]: Record the license that applies to the
+          content.
         - **content** ``bytea``: The raw compressed bytes of the content.
 
         **Metadata Columns**

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -297,8 +297,10 @@ class PrincipalSchema(Schema):
             __tablename__ = 'mesh_ref_annotations'
             _always_disp = ['pmid_num', 'mesh_num', 'qual_num']
             _indices = [BtreeIndex('mesh_ref_annotations_pmid_idx', 'pmid_num'),
-                        BtreeIndex('mesh_ref_annotations_mesh_id_idx', 'mesh_num'),
-                        BtreeIndex('mesh_ref_annotations_qual_id_idx', 'qual_num')]
+                        BtreeIndex('mesh_ref_annotations_mesh_id_idx',
+                                   'mesh_num'),
+                        BtreeIndex('mesh_ref_annotations_qual_id_idx',
+                                   'qual_num')]
             id = Column(Integer, primary_key=True)
             pmid_num = Column(Integer, nullable=False)
             mesh_num = Column(Integer, nullable=False)
@@ -306,8 +308,8 @@ class PrincipalSchema(Schema):
             major_topic = Column(Boolean, default=False)
             is_concept = Column(Boolean, default=False)
             __table_args__ = (
-                UniqueConstraint('pmid_num', 'mesh_num', 'qual_num', 'is_concept',
-                                 name='mesh-uniqueness'),
+                UniqueConstraint('pmid_num', 'mesh_num', 'qual_num',
+                                 'is_concept', name='mesh-uniqueness'),
             )
         return MeshRefAnnotations
 
@@ -425,6 +427,7 @@ class PrincipalSchema(Schema):
             insert_date = Column(DateTime, default=func.now())
             last_updated = Column(DateTime, onupdate=func.now())
             preprint = Column(Boolean)
+            license = Column(String)
             __table_args__ = (
                 UniqueConstraint('text_ref_id', 'source', 'format',
                                  'text_type', name='content-uniqueness'),

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -129,10 +129,13 @@ class PrincipalSchema(Schema):
         In addition we also track some basic metadata about the entry and
         updates to the data in the table.
 
-        - create_date ``timestamp without time zone``: The date the record was
-          added.
-        - last_updated ``timestamp without time zone``: The most recent time
-          the record was edited.
+        - **create_date** ``timestamp without time zone``: The date the record
+          was added.
+        - **last_updated** ``timestamp without time zone``: The most recent
+          time the record was edited.
+        - **pub_year** ``integer``: The year the article was published, based
+          on the first report we find (in order of PubMed, PMC, then PMC
+          Manuscripts).
 
         **Constraints**
 
@@ -189,6 +192,7 @@ class PrincipalSchema(Schema):
                         BtreeIndex('text_ref_pmcid_num_idx', 'pmcid_num'),
                         BtreeIndex('text_ref_doi_ns_idx', 'doi_ns'),
                         BtreeIndex('text_ref_doi_id_idx', 'doi_id'),
+                        BtreeIndex('text_ref_pub_year', 'pub_year'),
                         StringIndex('text_ref_doi_idx', 'doi')]
 
             id = Column(Integer, primary_key=True)
@@ -200,6 +204,7 @@ class PrincipalSchema(Schema):
             doi = Column(String(100))
             doi_ns = Column(Integer)
             doi_id = Column(String)
+            pub_year = Column(Integer)
             pii = Column(String(250))
             url = Column(String, unique=True)
             manuscript_id = Column(String(100), unique=True)


### PR DESCRIPTION
This PR significantly refactors how content updates are performed, removing multiprocessing and focusing on implementing a more usable API. The PR also continues the trend of putting more database logical work into SQL that is executed on the remote server. Specifically, the process of getting the new primary key IDs from the ref table after new refs are added.

This PR also adds the `pub_year` column to text refs, and `license` column to the text content.