### PR TITLE
Normalize names in sif dump

### DIFF
--- a/indra_db/cli/dump.py
+++ b/indra_db/cli/dump.py
@@ -286,7 +286,8 @@ class Sif(Dumper):
                  belief_file=belief_path,
                  reload=True,
                  reconvert=True,
-                 ro=self.db)
+                 ro=self.db,
+                 normalize_names=True)
 
 
 class Belief(Dumper):

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -272,6 +272,7 @@ def normalize_sif_names(sif_df: pd.DataFrame):
         sif_df.loc[truthy_b, 'agB_name'] = rename_b.name[truthy_b]
 
         # Check that there are no missing names
+        logger.info('Performing sanity checks')
         assert sum(pd.isna(sif_df.agA_name)) == 0
         assert sum(pd.isna(sif_df.agB_name)) == 0
 
@@ -280,7 +281,11 @@ def normalize_sif_names(sif_df: pd.DataFrame):
             zip(sif_df.agA_ns, sif_df.agA_id, sif_df.agA_name)).union(
             set(zip(sif_df.agB_ns, sif_df.agB_id, sif_df.agB_name))
         )
+        # Check that rename took place
         assert ns_id_name_tups_after != ns_id_name_tups
+        # Check that all new names are used
+        assert set(rename_df.name).issubset({n for _, _, n in ns_id_name_tups_after})
+        logger.info('Sif dataframe renamed successfully')
     else:
         logger.info('No names need renaming')
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -221,7 +221,7 @@ def normalize_sif_names(sif_df: pd.DataFrame):
 
     from indra.ontology.bio import bio_ontology
     bio_ontology.initialize()
-    logger.info('Normalizing duplicated names in sif dataframe')
+    logger.info('Normalizing names in sif dataframe')
 
     # Get the set of grounded entities
     ns_id_tups = set(

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -230,7 +230,7 @@ def normalize_sif_names(sif_df: pd.DataFrame):
     )
 
     # Get the ontology name if it exists and rename in dataframe
-    for ns_, id_ in ns_id_tups:
+    for ns_, id_ in tqdm(ns_id_tups):
         oname = bio_ontology.get_name(ns_, id_)
         if oname is not None:
             _rename(_ns=ns_, _id=id_, new_name=oname, sif=sif_df)

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -466,7 +466,7 @@ def get_parser():
 
 def dump_sif(src_count_file, res_pos_file, belief_file, df_file=None,
              db_res_file=None, csv_file=None, reload=True, reconvert=True,
-             ro=None):
+             ro=None, normalize_names: bool = False):
     """Build and dump a sif dataframe of PA statements with grounded agents
 
     Parameters
@@ -500,6 +500,9 @@ def dump_sif(src_count_file, res_pos_file, belief_file, df_file=None,
     ro : Optional[PrincipalDatabaseManager]
         Provide a DatabaseManager to load database content from. If not
         provided, `get_ro('primary')` will be used.
+    normalize_names :
+        If True, detect and try to merge name duplicates (same entity with
+        different names, e.g. Loratadin vs loratadin). Default: False
     """
     def _load_file(path):
         if isinstance(path, str) and path.startswith('s3:') or \
@@ -537,7 +540,8 @@ def dump_sif(src_count_file, res_pos_file, belief_file, df_file=None,
     # Convert the database query result into a set of pairwise relationships
     df = make_dataframe(pkl_filename=df_file, reconvert=reconvert,
                         db_content=db_content, src_count_dict=src_count,
-                        res_pos_dict=res_pos, belief_dict=belief)
+                        res_pos_dict=res_pos, belief_dict=belief,
+                        normalize_names=normalize_names)
 
     if csv_file:
         if isinstance(csv_file, str) and csv_file.startswith('s3:'):

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -216,7 +216,6 @@ def normalize_sif_names(sif_df: pd.DataFrame):
     logger.info('Getting ns, id, name tuples')
 
     # Get the set of grounded entities
-
     ns_id_name_tups = set(
         zip(sif_df.agA_ns, sif_df.agA_id, sif_df.agA_name)).union(
         set(zip(sif_df.agB_ns, sif_df.agB_id, sif_df.agB_name))
@@ -248,20 +247,26 @@ def normalize_sif_names(sif_df: pd.DataFrame):
 
     # Do merge on with relevant columns from sif for both A and B
     logger.info('Getting temporary dataframes for renaming')
+
+    # Get dataframe with ns, id, new name column
     rename_a = sif_df[['agA_ns', 'agA_id']].merge(
         right=rename_df,
         left_on=['agA_ns', 'agA_id'],
         right_on=['ns', 'id'], how='left'
     ).drop('ns', axis=1).drop('id', axis=1)
+
+    # Check which rows have name entries
     truthy_a = pd.notna(rename_a.name)
+
+    # Rename in sif_df from new names
     sif_df.loc[truthy_a, 'agA_name'] = rename_a.name[truthy_a]
 
+    # Repeat for agB_name
     rename_b = sif_df[['agB_ns', 'agB_id']].merge(
         right=rename_df,
         left_on=['agB_ns', 'agB_id'],
         right_on=['ns', 'id'], how='left'
     ).drop('ns', axis=1).drop('id', axis=1)
-    # Get notna rows of name column in rename
     truthy_b = pd.notna(rename_b.name)
     sif_df.loc[truthy_b, 'agB_name'] = rename_b.name[truthy_b]
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -510,7 +510,7 @@ def get_parser():
 
 def dump_sif(src_count_file, res_pos_file, belief_file, df_file=None,
              db_res_file=None, csv_file=None, reload=True, reconvert=True,
-             ro=None, normalize_names: bool = False):
+             ro=None, normalize_names: bool = True):
     """Build and dump a sif dataframe of PA statements with grounded agents
 
     Parameters

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -212,6 +212,7 @@ def normalize_sif_names(sif_df: pd.DataFrame):
         The sif dataframe
     """
     from indra.ontology.bio import bio_ontology
+    bio_ontology.initialize()
     logger.info('Normalizing duplicated names in sif dataframe')
 
     def _get_name_case_dupl(sif):

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -211,16 +211,6 @@ def normalize_sif_names(sif_df: pd.DataFrame):
     sif_df :
         The sif dataframe
     """
-    def _rename(_ns: str, _id: str, new_name: str, sif: pd.DataFrame):
-        sif.loc[
-            (sif.agA_id == _id) & (sif.agA_ns == _ns),
-            'agA_name'
-        ] = new_name
-        sif.loc[
-            (sif.agB_id == _id) & (sif.agB_ns == _ns),
-            'agB_name'
-        ] = new_name
-
     from indra.ontology.bio import bio_ontology
     bio_ontology.initialize()
     logger.info('Getting ns, id, name tuples')

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -245,7 +245,8 @@ def normalize_sif_names(sif_df: pd.DataFrame):
 
 
 def make_dataframe(reconvert, db_content, res_pos_dict, src_count_dict,
-                   belief_dict, pkl_filename=None):
+                   belief_dict, pkl_filename=None,
+                   normalize_names: bool = False):
     """Make a pickled DataFrame of the db content, one row per stmt.
 
     Parameters
@@ -267,6 +268,9 @@ def make_dataframe(reconvert, db_content, res_pos_dict, src_count_dict,
         reconverting). If an S3 path is given (i.e., pkl_filename starts with
         `s3:`), the file is loaded to/saved from S3. If not given,
         reloads the content (overriding reload).
+    normalize_names :
+        If True, detect and try to merge name duplicates (same entity with
+        different names, e.g. Loratadin vs loratadin). Default: False
 
     Returns
     -------
@@ -403,6 +407,8 @@ def make_dataframe(reconvert, db_content, res_pos_dict, src_count_dict,
             else:
                 with open(pkl_filename, 'rb') as f:
                     df = pickle.load(f)
+    if normalize_names:
+        normalize_sif_names(sif_df=df)
     return df
 
 

--- a/indra_db/util/dump_sif.py
+++ b/indra_db/util/dump_sif.py
@@ -200,9 +200,11 @@ def get_source_counts(pkl_filename=None, ro=None):
 def normalize_sif_names(sif_df: pd.DataFrame):
     """Try to normalize duplicated names in the sif dump dataframe
 
-    This process tries to normalize names of entities in the sif dump where
+    This function tries to normalize names of entities in the sif dump where
     the namespace and identifier are the same but the names differ,
-    e.g. 'Loratadine' vs 'loratadine' both with CHEBI:6538
+    e.g. 'Loratadine' vs 'loratadine' both with CHEBI:6538. The
+    'bio_ontology' is the arbiter of what constitutes a normalized
+    name. If no name exists, no further attempt to change the name is made.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR adds a check in the sif dump for entities that have the same grounding but different names. After the check, an attempt is made to normalize them using `indra.ontology.bio.BioOntology.get_name()`.