### PR TITLE
Limit sqlalchemy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def main():
           author_email='patrick_greene@hms.harvard.edu',
           packages=packages,
           include_package_data=True,
-          install_requires=['sqlalchemy', 'psycopg2'],
+          install_requires=['sqlalchemy<1.4', 'psycopg2'],
           extras_require=extras_require,
           entry_points="""
           [console_scripts]


### PR DESCRIPTION
This line: https://github.com/indralab/indra_db/blob/master/indra_db/databases.py#L58 is not compatible with SQLAlchemy 1.4, it appears the `_extra_froms` property was removed starting with that version. This PR adds a simple limit to the setup to make sure the latest compatible version of SQLAlchemy is installed.