### PR TITLE
Make termcolor and cachetools default dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def main():
                                   'flask-compress', 'numpy'],
                       'cli': ['click', 'boto3'],
                       'copy': ['pgcopy'],
-                      'misc': ['cachetools', 'matplotlib', 'numpy', 'termcolor']}
+                      'misc': ['matplotlib', 'numpy']}
     extras_require['all'] = list({dep for deps in extras_require.values()
                                   for dep in deps})
     setup(name='indra_db',
@@ -22,7 +22,8 @@ def main():
           author_email='patrick_greene@hms.harvard.edu',
           packages=packages,
           include_package_data=True,
-          install_requires=['sqlalchemy<1.4', 'psycopg2'],
+          install_requires=['sqlalchemy<1.4', 'psycopg2', 'cachetools',
+                            'termcolor'],
           extras_require=extras_require,
           entry_points="""
           [console_scripts]


### PR DESCRIPTION
Currently, doing a simple `import indra_db` fails if only the default dependencies are installed since both `termcolor` and `cachetools` are imported in locations that are loaded centrally in the module. So this PR makes them default dependencies to allow importing indra_db upon a basic install without extras.