### PR TITLE
Reading jobs modifications

### DIFF
--- a/indra_db/cli/reading.py
+++ b/indra_db/cli/reading.py
@@ -269,7 +269,8 @@ class BulkAwsReadingManager(BulkReadingManager):
                            self.ids_per_job[reader_name.lower()])
 
         logger.info("Waiting for complete...")
-        sub.watch_and_wait(idle_log_timeout=self.timeouts[reader_name.lower()],
+        sub.watch_and_wait(poll_interval=30,
+                           idle_log_timeout=self.timeouts[reader_name.lower()],
                            kill_on_timeout=True, stash_log_method='s3')
 
         # Get the versions of the reader reader used in all the jobs, check for


### PR DESCRIPTION
This PR changes the order of running reading jobs and increases the interval for checking the jobs status for monitoring from 10 to 30 seconds to reduce logging.