### PR TITLE
Manuscripts content upload update

### DIFF
--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -95,7 +95,8 @@ class _NihFtpClient(object):
         logger.info("Parsing XML metadata")
         return ET.XML(xml_bytes, parser=UTB())
 
-    def get_csv_as_dict(self, csv_file, cols=None, infer_header=True):
+    def get_csv_as_dict(self, csv_file, cols=None, infer_header=True,
+                        add_fields=None):
         """Get the content from a csv file as a list of dicts.
 
         Parameters
@@ -107,6 +108,8 @@ class _NihFtpClient(object):
         infer_header : bool
             If True, infer the cols from the first line. If False, the cols
             will simply be indexed by integers.
+        add_fields : dict
+            A dictionary of additional fields to add to the dicts.
         """
         csv_str = self.get_file(csv_file)
         csv_lines = csv_str.splitlines()
@@ -118,7 +121,10 @@ class _NihFtpClient(object):
                     continue
                 else:
                     cols = list(range(len(row)))
-            result.append(dict(zip(cols, row)))
+            row_dict = dict(zip(cols, row))
+            if add_fields is not None:
+                row_dict.update(add_fields)
+            result.append(row_dict)
         return result
 
     def ret_file(self, f_path, buf):

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -902,8 +902,12 @@ class PmcManager(_NihManager):
 
     def __init__(self, *args, **kwargs):
         super(PmcManager, self).__init__(*args, **kwargs)
+        self.file_data = self.get_file_data()
 
     def update(self, db):
+        raise NotImplementedError
+
+    def get_file_data(self):
         raise NotImplementedError
 
     @staticmethod
@@ -1345,7 +1349,7 @@ class PmcOA(PmcManager):
     def __init__(self, *args, **kwargs):
         super(PmcOA, self).__init__(*args, **kwargs)
         self.licenses = {d['Accession ID']: d['License']
-                         for d in self.get_file_data()}
+                         for d in self.file_data}
 
     def get_license(self, pmcid):
         return self.licenses[pmcid]
@@ -1363,8 +1367,7 @@ class PmcOA(PmcManager):
         return files_metadata
 
     def get_pmcid_file_dict(self):
-        file_data = self.get_file_data()
-        return {d['Accession ID']: d['File'] for d in file_data}
+        return {d['Accession ID']: d['File'] for d in self.file_data}
 
     def get_archives_after_date(self, min_date):
         """Get the names of all single-article archives after the given date."""
@@ -1426,7 +1429,7 @@ class Manuscripts(PmcManager):
         return ftp_file_list
 
     def get_pmcid_file_dict(self):
-        return {d['AccessionID']: d['Article File'] for d in self.get_file_data()}
+        return {d['AccessionID']: d['Article File'] for d in self.file_data}
 
     def get_tarname_from_filename(self, fname):
         "Get the name of the tar file based on the file name (or a pmcid)."
@@ -1473,8 +1476,7 @@ class Manuscripts(PmcManager):
         The continuing feature isn't implemented yet.
         """
         logger.info("Getting list of manuscript content available.")
-        ftp_file_list = self.get_file_data()
-        ftp_pmcid_set = {entry['AccessionID'] for entry in ftp_file_list}
+        ftp_pmcid_set = {entry['AccessionID'] for entry in self.file_data}
 
         logger.info("Getting a list of text refs that already correspond to "
                     "manuscript content.")
@@ -1490,7 +1492,7 @@ class Manuscripts(PmcManager):
 
         logger.info("Determining which archives need to be loaded.")
         update_archives = defaultdict(set)
-        for file_dict in ftp_file_list:
+        for file_dict in self.file_data:
             pmcid = file_dict['AccessionID']
             if pmcid in load_pmcid_set:
                 update_archives[file_dict['archive']].add(pmcid)

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1473,8 +1473,8 @@ class Manuscripts(PmcManager):
         The continuing feature isn't implemented yet.
         """
         logger.info("Getting list of manuscript content available.")
-        ftp_file_list = self.ftp.get_csv_as_dict('filelist.csv')
-        ftp_pmcid_set = {entry['PMCID'] for entry in ftp_file_list}
+        ftp_file_list = self.get_file_data()
+        ftp_pmcid_set = {entry['AccessionID'] for entry in ftp_file_list}
 
         logger.info("Getting a list of text refs that already correspond to "
                     "manuscript content.")
@@ -1488,10 +1488,12 @@ class Manuscripts(PmcManager):
         logger.info("There are %d manuscripts to load."
                     % (len(load_pmcid_set)))
 
-        logger.info("Determining which archives need to be laoded.")
+        logger.info("Determining which archives need to be loaded.")
         update_archives = defaultdict(set)
-        for pmcid in load_pmcid_set:
-            update_archives[f'PMC00{pmcid[3]}XXXXXX.xml.tar.gz'].add(pmcid)
+        for file_dict in ftp_file_list:
+            pmcid = file_dict['AccessionID']
+            if pmcid in load_pmcid_set:
+                update_archives[file_dict['archive']].add(pmcid)
 
         logger.info("Beginning to upload archives.")
         for archive, pmcid_set in sorted(update_archives.items()):

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1409,11 +1409,24 @@ class Manuscripts(PmcManager):
     def get_license(self, pmcid):
         return 'manuscripts'
 
+    def get_csv_files(self):
+        """Get a list of CSV files from the FTP server."""
+        all_files = self.ftp.ftp_ls('xml')
+        return [f for f in all_files if f.endswith('filelist.csv')]
+
     def get_file_data(self):
-        return self.ftp.get_csv_as_dict("filelist.csv")
+        files = self.get_csv_files()
+        ftp_file_list = []
+        for f in files:
+            file_root = f.split('.filelist')[0]
+            archive = self.ftp._path_join('xml', f'{file_root}.tar.gz')
+            ftp_file_list += self.ftp.get_csv_as_dict(
+                self.ftp._path_join('xml', f),
+                add_fields={'archive': archive})
+        return ftp_file_list
 
     def get_pmcid_file_dict(self):
-        return {d['PMCID']: d['File'] for d in self.get_file_data()}
+        return {d['AccessionID']: d['Article File'] for d in self.get_file_data()}
 
     def get_tarname_from_filename(self, fname):
         "Get the name of the tar file based on the file name (or a pmcid)."

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1049,11 +1049,13 @@ class PmcManager(_NihManager):
             e.get('pub-id-type'): e.text for e in
             tree.findall('.//article-id')
             }
-        if 'pmc' not in id_data.keys():
-            logger.info("Did not get a 'pmc' in %s." % filename)
-            return None
         if 'pmcid' not in id_data.keys():
-            id_data['pmcid'] = 'PMC' + id_data['pmc']
+            if 'pmc' in id_data.keys():
+                pmcid = 'PMC' + id_data['pmc']
+            else:
+                pmcid = filename.split('/')[1].split('.')[0]
+            id_data['pmcid'] = pmcid
+            logger.info('Processing XML for %s.' % pmcid)
         if 'manuscript' in id_data.keys():
             id_data['manuscript_id'] = id_data['manuscript']
 
@@ -1352,7 +1354,7 @@ class PmcOA(PmcManager):
 
     def __init__(self, *args, **kwargs):
         super(PmcOA, self).__init__(*args, **kwargs)
-        self.licenses = {d['Accession ID']: d['License']
+        self.licenses = {d['AccessionID']: d['License']
                          for d in self.file_data}
 
     def get_license(self, pmcid):

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1051,7 +1051,10 @@ class PmcManager(_NihManager):
             }
         if 'pmcid' not in id_data.keys():
             if 'pmc' in id_data.keys():
-                pmcid = 'PMC' + id_data['pmc']
+                if id_data['pmc'].startswith('PMC'):
+                    pmcid = id_data['pmc']
+                else:
+                    pmcid = 'PMC' + id_data['pmc']
             else:
                 pmcid = filename.split('/')[1].split('.')[0]
             id_data['pmcid'] = pmcid


### PR DESCRIPTION
This PR changes the PMC manager and Manuscripts content upload process to work with changes in NIH FTP service. More specifically instead of processing a single metadata file, it processes a list of baseline and incremental files to get the PMCIDs that are missing from DB and need to be downloaded. See for the change description https://www.ncbi.nlm.nih.gov/labs/pmc/tools/ftp/#ftpupdate

P.S. It looks like we soon might need to do the same update for the PmcOA class as well since the bulk download structure is updated for both Manuscript and PMC OA. Processing the metadata files part should be almost identical. It is not a part of this PR because:
1) While the folder structure is the same for OA files and manuscripts, the structure of XMLs is different so we can't reuse the same XML parsing code.
2) The "older" version of using a single metadata file and single article archives is still supported for OA articles and works.