### PR TITLE
Dumping updates

### DIFF
--- a/indra_db/cli/dump.py
+++ b/indra_db/cli/dump.py
@@ -641,8 +641,8 @@ class ReadonlyTransferEnv(object):
 dumpers = {dumper.name: dumper for dumper in get_all_descendants(Dumper)}
 
 
-def dump(principal_db, readonly_db, delete_existing=False, allow_continue=True,
-         load_only=False, dump_only=False):
+def dump(principal_db, readonly_db=None, delete_existing=False,
+         allow_continue=True, load_only=False, dump_only=False):
     """Run the suite of dumps in the specified order.
 
     Parameters
@@ -650,7 +650,7 @@ def dump(principal_db, readonly_db, delete_existing=False, allow_continue=True,
     principal_db : :class:`indra_db.databases.PrincipalDatabaseManager`
         A handle to the principal database.
     readonly_db : :class:`indra_db.databases.ReadonlyDatabaseManager`
-        A handle to the readonly database.
+        A handle to the readonly database. Optional when running dump only.
     delete_existing : bool
         If True, clear out the existing readonly build from the principal
         database. Otherwise it will be continued. (Default is False)
@@ -665,6 +665,10 @@ def dump(principal_db, readonly_db, delete_existing=False, allow_continue=True,
         Do not load a new readonly database, only produce the dump files on s3.
         (Default is False)
     """
+    # Check if readonly is needed:
+    if not dump_only:
+        raise ValueError("readonly_db must be provided with when "
+                         "dump_only == False")
     if not load_only:
         # START THE DUMP
         if delete_existing and 'readonly' in principal_db.get_schemas():

--- a/indra_db/cli/dump.py
+++ b/indra_db/cli/dump.py
@@ -666,7 +666,7 @@ def dump(principal_db, readonly_db=None, delete_existing=False,
         (Default is False)
     """
     # Check if readonly is needed:
-    if not dump_only:
+    if not dump_only and readonly_db is None:
         raise ValueError("readonly_db must be provided with when "
                          "dump_only == False")
     if not load_only:
@@ -780,7 +780,8 @@ def run_all(continuing, delete_existing, load_only, dump_only):
     """Generate new dumps and list existing dumps."""
     from indra_db import get_ro
 
-    if not dump_only and not load_only:
+    # Check if the readonly db handle is needed
+    if not dump_only:
         ro_manager = get_ro('primary', protected=False)
     else:
         ro_manager = None

--- a/indra_db/cli/dump.py
+++ b/indra_db/cli/dump.py
@@ -779,8 +779,14 @@ def dump(principal_db, readonly_db=None, delete_existing=False,
 def run_all(continuing, delete_existing, load_only, dump_only):
     """Generate new dumps and list existing dumps."""
     from indra_db import get_ro
+
+    if not dump_only and not load_only:
+        ro_manager = get_ro('primary', protected=False)
+    else:
+        ro_manager = None
+
     dump(get_db('primary', protected=False),
-         get_ro('primary', protected=False), delete_existing,
+         ro_manager, delete_existing,
          continuing, load_only, dump_only)
 
 


### PR DESCRIPTION
This PR makes it possible to run `indra-db dump run all --dump-only` without having to set `INDRAROPRIMARY` as an environment variable as the readonly db is not needed when only dumping.

_NOTE: Testing the code will start a new dump run. If testing, make sure to delete the files created on S3._