### PR TITLE
Catch error in debug print

### DIFF
--- a/indra_db/client/readonly/query.py
+++ b/indra_db/client/readonly/query.py
@@ -517,6 +517,12 @@ class Query(object):
 
         # Put it all together.
         selection = select(cols).select_from(stmts_q)
+
+        # This try-except section handles a sqlalchemy error that occurs when
+        # trying to compile a string of the query.
+        # See: https://github.com/sqlalchemy/sqlalchemy/issues/6514
+        # The string is only used for printing and ignoring it does not affect
+        # the query.
         try:
             selection_print = selection.compile(compile_kwargs={'literal_binds': True})
             if self._print_only:

--- a/indra_db/client/readonly/query.py
+++ b/indra_db/client/readonly/query.py
@@ -517,13 +517,18 @@ class Query(object):
 
         # Put it all together.
         selection = select(cols).select_from(stmts_q)
-        selection_print = selection.compile(compile_kwargs={'literal_binds': True})
-        if self._print_only:
-            print(selection_print)
-            return
+        try:
+            selection_print = selection.compile(compile_kwargs={'literal_binds': True})
+            if self._print_only:
+                print(selection_print)
+                return
 
-        logger.info("Executing query (get_statements)")
-        logger.debug(f"SQL:\n{selection_print}")
+            logger.info("Executing query (get_statements)")
+            logger.debug(f"SQL:\n{selection_print}")
+        except Exception as err:
+            if self._print_only:
+                raise err
+            logger.warning("Could not print query")
 
         # Execute the query.
         proxy = ro.session.connection().execute(selection)


### PR DESCRIPTION
This PR catches a SQLAlchemy error coming from attempting to print out queries. It simply wraps the code that errors in a try-except and ignores any attempts to print the query if it errors.

With this fix, follow-up queries that drills down to the evidence level of statements that previously gave http 500 errors now work for the client.