### PR TITLE
Use pathlib.Path and set absolute paths

### DIFF
--- a/indra_db_service/config.py
+++ b/indra_db_service/config.py
@@ -1,12 +1,17 @@
+__all__ = ["TITLE", "DEPLOYMENT", "VUE_ROOT", "MAX_STMTS", "MAX_LIST_LEN",
+           "REDACT_MESSAGE", "TESTING", "jwt_nontest_optional"]
+
 from os import environ
+from pathlib import Path
 from flask_jwt_extended import jwt_optional
 
 TITLE = "The INDRA Database"
 DEPLOYMENT = environ.get('INDRA_DB_API_DEPLOYMENT')
 VUE_ROOT = environ.get('INDRA_DB_API_VUE_ROOT')
-if VUE_ROOT is not None and VUE_ROOT.endswith('/'):
-    # Peal off the trailing slash.
-    VUE_ROOT = VUE_ROOT[:-1]
+if VUE_ROOT is not None:
+    VUE_ROOT = Path(VUE_ROOT).expanduser()
+    if not VUE_ROOT.is_absolute():
+        VUE_ROOT = Path(__file__).parent.absolute() / VUE_ROOT
 MAX_STMTS = 500
 MAX_LIST_LEN = 2000
 REDACT_MESSAGE = '[MISSING/INVALID CREDENTIALS: limited to 200 char for Elsevier]'


### PR DESCRIPTION
This PR consists of a cherry-picked and slightly modified commit from the [ui-updates](https://github.com/pagreene/indra_db/commit/43446d8623918979fb09cc6b99ecd6cb458c7054) branch and makes it possible to run `indra-db-service test-service` from anywhere (if the command is available) by using absolute paths.