### PR TITLE
Test deployed vue package files

### DIFF
--- a/indra_db_service/api.py
+++ b/indra_db_service/api.py
@@ -201,8 +201,15 @@ def search():
     stmt_types -= {'Influence', 'Event', 'Unresolved'}
     stmt_types_json = json.dumps(sorted(list(stmt_types)))
     if TESTING['status']:
-        vue_src = url_for("serve_indralab_vue", file='IndralabVue.umd.js')
-        vue_style = url_for("serve_indralab_vue", file='IndralabVue.css')
+        if not TESTING['deployment']:
+            vue_src = url_for("serve_indralab_vue", file='IndralabVue.umd.js')
+            vue_style = url_for("serve_indralab_vue", file='IndralabVue.css')
+        else:
+            vue_root = TESTING['vue-root']
+            logging.info(f"Testing deployed vue files at: {vue_root}")
+            vue_src = f'{vue_root}/IndralabVue.umd.js'
+            vue_style = f'{vue_root}/IndralabVue.css'
+
     else:
         vue_src = f'{VUE_ROOT}/IndralabVue.umd.js'
         vue_style = f'{VUE_ROOT}/IndralabVue.css'

--- a/indra_db_service/cli/__init__.py
+++ b/indra_db_service/cli/__init__.py
@@ -27,10 +27,23 @@ def push(deployment):
               help="Override the default port number.")
 @click.option('-h', '--host', default='0.0.0.0',
               help="Override the default host.")
-def test_service(port, host):
+@click.option('--deployment',
+              help="Load the vue package from this S3 deployment instead of "
+                   "a local directory.")
+def test_service(port, host, deployment=None):
     """Run the service in test mode locally."""
     from indra_db_service.config import TESTING
     TESTING['status'] = True
+    if deployment is not None:
+        TESTING['deployment'] = deployment
+        TESTING['vue-root'] = (
+            f'https://bigmech.s3.amazonaws.com/indra-db/indralabvue-'
+            f'{deployment}'
+        )
+        click.echo(f'Using deployment {deployment} from S3 at {TESTING["vue-root"]}')
+    else:
+        TESTING['deployment'] = ''
+        TESTING['vue-root'] = ''
 
     from indra_db_service.api import app
     app.run(host=host, port=port, debug=True)


### PR DESCRIPTION
This PR adds the capability to test a vue-package deployment from S3 locally. When starting running `indra-db-service test-service`, add the option `--deployment <deployment name>`, where `<deployment name>` can be `latest`, `dev`, `test` etc.

This option is good as a last local test before testing the service on lambda.