### PR TITLE
Statement Temporal Information on Summary Page

### DIFF
--- a/indra_db/util/visualization.py
+++ b/indra_db/util/visualization.py
@@ -546,6 +546,142 @@ def pmid_vs_statement_graph():
     plt.show()
     return fig
 
+
+def discovery_year_distribution_graph(pmid_years_types_fpath, hash_to_pmid_fpath):
+    """Generate the discovery year distribution from PMID/year inputs.
+    Expected input formats:
+
+    pmid_year_types:
+        A gzipped TSV file with one row per PMID:
+        PMID<TAB>YEAR<TAB>TYPE
+
+    hash_to_pmid:
+        A gzipped JSON object mapping each statement hash to its supporting PMIDs:
+        {
+            "stmt_hash": ["pmid1", "pmid2", ...]
+        }
+    """
+    pmid_to_year = {}
+    with gzip.open(pmid_years_types_fpath, "rt") as f:
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 2:
+                continue
+            try:
+                pmid_to_year[parts[0]] = int(parts[1])
+            except ValueError:
+                continue
+
+    earliest_years = []
+    with gzip.open(hash_to_pmid_fpath, "rt") as f:
+        hash_to_pmids = json.load(f)
+
+    for _, pmids in hash_to_pmids.items():
+        years = []
+        for pmid in pmids:
+            year = pmid_to_year.get(str(pmid))
+            if year is not None:
+                years.append(year)
+        if years:
+            earliest_year = min(years)
+            if earliest_year >= 1799:
+                earliest_years.append(earliest_year)
+
+    fig, ax = plt.subplots(figsize=(14, 6))
+    ax.hist(earliest_years, bins=75)
+    ax.set_title("Distribution of Earliest Publication Year per Statement (1799-2026)")
+    ax.set_xlabel("Earliest Publication Year")
+    ax.set_ylabel("Number of Statements")
+    fig.tight_layout()
+
+    df = pd.DataFrame({"earliest_year": earliest_years})
+    return fig, ax, df
+
+
+def lifespan_by_discovery_year_graph(pmid_years_types_fpath, hash_to_pmid_fpath):
+    """Generate lifespan statistics by discovery year from PMID/year inputs.
+    Expected input formats:
+
+    pmid_year_types:
+        A gzipped TSV file with one row per PMID:
+        PMID<TAB>YEAR<TAB>TYPE
+
+    hash_to_pmid:
+        A gzipped JSON object mapping each statement hash to its supporting PMIDs:
+        {
+            "stmt_hash": ["pmid1", "pmid2", ...]
+        }
+    """
+    pmid_to_year = {}
+    with gzip.open(pmid_years_types_fpath, "rt") as f:
+        for line in f:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 2:
+                continue
+            try:
+                pmid_to_year[parts[0]] = int(parts[1])
+            except ValueError:
+                continue
+
+    lifespans_by_year = defaultdict(list)
+    with gzip.open(hash_to_pmid_fpath, "rt") as f:
+        hash_to_pmids = json.load(f)
+
+    for _, pmids in hash_to_pmids.items():
+        years = []
+        for pmid in pmids:
+            year = pmid_to_year.get(str(pmid))
+            if year is not None:
+                years.append(year)
+        if years:
+            earliest_year = min(years)
+            lifespans_by_year[earliest_year].append(max(years) - earliest_year)
+
+    rows = []
+    for year, lifespans in sorted(lifespans_by_year.items()):
+        if len(lifespans) < 100:
+            continue
+        values = np.array(lifespans)
+        rows.append({
+            "earliest_year": year,
+            "statement_count": len(values),
+            "mean_lifespan": values.mean(),
+            "p50": np.quantile(values, 0.50),
+            "p75": np.quantile(values, 0.75),
+            "p90": np.quantile(values, 0.90),
+            "p99": np.quantile(values, 0.99),
+        })
+
+    year_stats = pd.DataFrame(
+        rows,
+        columns=[
+            "earliest_year", "statement_count", "mean_lifespan",
+            "p50", "p75", "p90", "p99"
+        ]
+    ).set_index("earliest_year")
+
+    fig, ax1 = plt.subplots(figsize=(16, 7))
+    ax1.plot(year_stats.index, year_stats["mean_lifespan"], linewidth=3, label="Mean")
+    ax1.plot(year_stats.index, year_stats["p50"], linewidth=2, label="P50")
+    ax1.plot(year_stats.index, year_stats["p75"], linewidth=2, label="P75")
+    ax1.plot(year_stats.index, year_stats["p90"], linewidth=2, label="P90")
+    ax1.plot(year_stats.index, year_stats["p99"], linewidth=2, label="P99")
+    ax1.set_xlabel("Earliest Publication Year")
+    ax1.set_ylabel("Lifespan (years)")
+    ax1.grid(True, alpha=0.3)
+    ax1.legend(loc="upper right")
+
+    ax2 = ax1.twinx()
+    ax2.set_yscale("log")
+    ax2.bar(year_stats.index, year_stats["statement_count"], alpha=0.25, color="gray")
+    ax2.set_ylabel("Number of Statements")
+
+    ax1.set_title("Statement Lifespan and Statement Production by Discovery Year")
+    fig.tight_layout()
+
+    return fig, (ax1, ax2), year_stats
+
+
 def compute_total_evidence():
     with open(source_counts_fpath.as_posix(), "rb") as f:
         source_count = pickle.load(f)
@@ -725,4 +861,3 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
     generate_all_plots(args.output_dir, refresh=args.refresh)
-

--- a/indra_db_service/templates/summary.html
+++ b/indra_db_service/templates/summary.html
@@ -80,7 +80,7 @@
             <li><a class="nav-link" href="#entity-interactions">Statements by Entity Type</a></li>
             <li><a class="nav-link" href="#sources">Sources</a></li>
             <li><a class="nav-link" href="#content-insights">Content Insights</a></li>
-            <li><a class="nav-link" href="#temporal-characteristics">Temporal characteristics of biomedical knowledge.</a></li>
+            <li><a class="nav-link" href="#temporal-characteristics">Temporal characteristics</a></li>
             <li><a class="nav-link" href="#gene-mesh">Gene-Disease MeSH Distributions</a></li>
         </ul>
       </nav>
@@ -410,7 +410,7 @@
 
       <div class="row mb-4">
          <div class="col-12">
-            <h2 class="border-bottom pb-2 mb-4">Temporal characteristics of biomedical knowledge.</h2>
+            <h2 class="border-bottom pb-2 mb-4">Temporal characteristics of biomedical knowledge</h2>
          </div>
       </div>
 
@@ -420,7 +420,12 @@
                  class="img-fluid zoomable" style="max-height: 300px; cursor: pointer;" alt="Discovery Year Distribution" onclick="showImage(this)">
           </div>
           <div class="col-md-5">
-             <p class="text-justify">Distribution of earliest publication years across all statement</p>
+             <h5>Discovery Year Distribution</h5>
+                <p class="text-justify">
+                   This figure shows the earliest publication year associated with each statement.
+                   Most statements come from recent decades, with a strong increase after 2000 and a peak around 2020–2025.
+                   This reflects the rapid growth of biomedical literature and newly reported biological mechanisms.
+                </p>
           </div>
       </div>
 
@@ -430,8 +435,12 @@
                  class="img-fluid zoomable" style="max-height: 300px; cursor: pointer;" alt="Lifespan by Discovery Year" onclick="showImage(this)">
           </div>
           <div class="col-md-5">
-             <p class="text-justify">Mean lifespan and lifespan percentiles as a function of discovery year together with
-statement production.</p>
+             <h5>Lifespan by Discovery Year</h5>
+                <p class="text-justify">
+                   This figure shows how statement lifespan changes by discovery year.
+                   The lines show mean lifespan and selected percentiles, while the grey bars show the number of newly appearing statements on a log scale.
+                   Overall, statement production increases over time, while statement longevity decreases.
+                </p>
           </div>
       </div>
 

--- a/indra_db_service/templates/summary.html
+++ b/indra_db_service/templates/summary.html
@@ -6,7 +6,7 @@
   <style>
         #app { padding-top: 0; }
         #toc.sticky-top { top: 90px; }
-        #database-statistics, #sources, #entity-interactions #content-insights, #gene-mesh, #database-summary{
+        #database-statistics, #sources, #entity-interactions #content-insights, #temporal-characteristics, #gene-mesh, #database-summary{
           scroll-margin-top: 110px;
         }
           main.container {
@@ -80,6 +80,7 @@
             <li><a class="nav-link" href="#entity-interactions">Statements by Entity Type</a></li>
             <li><a class="nav-link" href="#sources">Sources</a></li>
             <li><a class="nav-link" href="#content-insights">Content Insights</a></li>
+            <li><a class="nav-link" href="#temporal-characteristics">Temporal characteristics of biomedical knowledge.</a></li>
             <li><a class="nav-link" href="#gene-mesh">Gene-Disease MeSH Distributions</a></li>
         </ul>
       </nav>
@@ -399,6 +400,38 @@
              <h5>PMID vs Statement Count</h5>
              <p class="text-justify">The plot shows a strong inverse relationship between the number of unique PMIDs per statement and the number of statements on a log–log scale.
                  The distribution is highly skewed, with most statements supported by only a few PMIDs, while a small fraction of statements accumulate evidence from hundreds to tens of thousands of publications.</p>
+          </div>
+      </div>
+
+    </div>
+
+
+    <div class="container-fluid" id="temporal-characteristics">
+
+      <div class="row mb-4">
+         <div class="col-12">
+            <h2 class="border-bottom pb-2 mb-4">Temporal characteristics of biomedical knowledge.</h2>
+         </div>
+      </div>
+
+      <div class="row mb-5 align-items-center">
+          <div class="col-md-7 text-center">
+            <img src="{{ url_for('static', filename='plots/discovery_year_distribution.png') }}"
+                 class="img-fluid zoomable" style="max-height: 300px; cursor: pointer;" alt="Discovery Year Distribution" onclick="showImage(this)">
+          </div>
+          <div class="col-md-5">
+             <p class="text-justify">Distribution of earliest publication years across all statement</p>
+          </div>
+      </div>
+
+      <div class="row mb-5 align-items-center">
+          <div class="col-md-7 text-center">
+            <img src="{{ url_for('static', filename='plots/lifespan_by_discovery_year.png') }}"
+                 class="img-fluid zoomable" style="max-height: 300px; cursor: pointer;" alt="Lifespan by Discovery Year" onclick="showImage(this)">
+          </div>
+          <div class="col-md-5">
+             <p class="text-justify">Mean lifespan and lifespan percentiles as a function of discovery year together with
+statement production.</p>
           </div>
       </div>
 


### PR DESCRIPTION
This PR adds two more graphs to the db.indra.bio summary page about the temporal information of statements from indra. One is the discovery-year distribution, and the other is lifespan by discovery year.